### PR TITLE
🐞 Bugfix – Update Homepage template used by elm-land init

### DIFF
--- a/cli/package-lock.json
+++ b/cli/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "elm-land",
-  "version": "0.12.0",
+  "version": "0.14.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "elm-land",
-      "version": "0.12.0",
+      "version": "0.14.1",
       "license": "ISC",
       "dependencies": {
         "chokidar": "3.5.3",

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "elm-land",
-  "version": "0.14.0",
+  "version": "0.14.1",
   "description": "Reliable web apps for everyone",
   "main": "index.js",
   "bin": {

--- a/cli/src/templates/src/Pages/Home_.elm
+++ b/cli/src/templates/src/Pages/Home_.elm
@@ -1,8 +1,11 @@
 module Pages.Home_ exposing (page)
 
-import Html exposing (Html)
+import Html
+import View exposing (View)
 
 
-page : Html msg
+page : View msg
 page =
-    Html.text "Hello, world!"
+    { title = "Homepage"
+    , body = [ Html.text "Hello, world!" ]
+    }


### PR DESCRIPTION
## Problem

The last release did not update the `src/Pages/Home_.elm` file created when users run `npx elm-land init`

## Solution

- Update that file to expose `page : View msg`
- Wish I had better tests ( need to implement `elm-land build` next!! )