### PR TITLE
🐞 Bug Fix – Port isn't reading from environment variable

### DIFF
--- a/cli/src/commands/server.js
+++ b/cli/src/commands/server.js
@@ -17,6 +17,8 @@ let run = async () => {
     // TODO: Warn user about invalid config JSON
   }
 
+  let port = process.env.PORT || 1234
+
   return {
     message: ({ port }) => [
       '',
@@ -25,7 +27,7 @@ let run = async () => {
     files: [],
     effects: [
       { kind: 'generateHtml', config },
-      { kind: 'runServer', options: { port: 1234 } }
+      { kind: 'runServer', options: { port: port } }
     ]
   }
 }

--- a/cli/src/effects.js
+++ b/cli/src/effects.js
@@ -364,7 +364,7 @@ const generateHtml = async (config) => {
 let run = async (effects) => {
   // 1. Perform all effects, one at a time
   let results = []
-  let port = process.env.PORT || 1234
+  let port = undefined;
 
   for (let effect of effects) {
     switch (effect.kind) {


### PR DESCRIPTION
## Problem

When a user specifies a custom port via `PORT=2345 elm-land server`, we aren't passing that information along to the server. This means the port will always be the default `1234` (unless there is a conflict)

## Solution

@MattCheely replaced the hardcoded `1234` with a line that actually reads from the ENV variable. Thanks, Matt!