### PR TITLE
🐞 Bug fix – Dynamic parameters should be using camelCase

### DIFF
--- a/cli/src/codegen/src/Commands/Generate.elm
+++ b/cli/src/codegen/src/Commands/Generate.elm
@@ -1367,7 +1367,7 @@ toRoutePathToStringBranch file =
                             if String.endsWith "_" piece then
                                 CodeGen.Expression.value
                                     ("params."
-                                        ++ (piece |> String.dropRight 1 |> Extras.String.fromPascalCaseToKebabCase)
+                                        ++ (piece |> String.dropRight 1 |> Extras.String.fromPascalCaseToCamelCase)
                                     )
 
                             else

--- a/examples/02-pages-and-layouts/src/Pages/Users/UserId_.elm
+++ b/examples/02-pages-and-layouts/src/Pages/Users/UserId_.elm
@@ -1,0 +1,70 @@
+module Pages.Users.UserId_ exposing (Model, Msg, page)
+
+import Effect exposing (Effect)
+import Route exposing (Route)
+import Html
+import Page exposing (Page)
+import Shared
+import View exposing (View)
+
+
+page : Shared.Model -> Route { userId : String } -> Page Model Msg
+page shared route =
+    Page.new
+        { init = init
+        , update = update
+        , subscriptions = subscriptions
+        , view = view
+        }
+
+
+
+-- INIT
+
+
+type alias Model =
+    {}
+
+
+init : () -> ( Model, Effect Msg )
+init () =
+    ( {}
+    , Effect.none
+    )
+
+
+
+-- UPDATE
+
+
+type Msg
+    = ExampleMsgReplaceMe
+
+
+update : Msg -> Model -> ( Model, Effect Msg )
+update msg model =
+    case msg of
+        ExampleMsgReplaceMe ->
+            ( model
+            , Effect.none
+            )
+
+
+
+-- SUBSCRIPTIONS
+
+
+subscriptions : Model -> Sub Msg
+subscriptions model =
+    Sub.none
+
+
+
+-- VIEW
+
+
+view : Model -> View Msg
+view model =
+    { title = "Pages.Users.UserId_"
+    , body = [ Html.text "/users/:userId" ]
+    }


### PR DESCRIPTION
## Problem

When creating a new page with a camel-case identifier in the url (e.g.
/users/:userId), Route.Path.toString was generating a record accessor
with  `fromPascalCaseToKebabCase` instead of `fromPascalCaseToCamelCase`.

This leads to compiler errors after running the `elm-land add page` command

## Solution

@MattCheely used the existing `fromPascalCaseToCamelCase` function to ensure that we aren't causing problems for folks adding new pages