### PR TITLE
:lady_beetle: Bug Fix - Better missed error handling

### DIFF
--- a/cli/src/templates/_elm-land/server/main.js
+++ b/cli/src/templates/_elm-land/server/main.js
@@ -105,7 +105,7 @@ let startApp = ({ Interop }) => {
     setTimeout(() => {
       let overlay = document.querySelector('elm-error-overlay')
       if (!overlay) {
-        window.location.reload()
+        import.meta.hot.send('elm:missing-error')
       }
     }, 300)
   }

--- a/cli/src/templates/_elm-land/server/main.js
+++ b/cli/src/templates/_elm-land/server/main.js
@@ -100,14 +100,10 @@ let startApp = ({ Interop }) => {
     if (Interop.onReady) {
       Interop.onReady({ app, env })
     }
-  } else if (import.meta.env.DEV) {
-    // Ensure error overlay shows in dev mode
-    setTimeout(() => {
-      let overlay = document.querySelector('elm-error-overlay')
-      if (!overlay) {
-        import.meta.hot.send('elm:missing-error')
-      }
-    }, 300)
+  }
+
+  if (import.meta.env.DEV) {
+    import.meta.hot.send('elm:client-ready')
   }
 
 }

--- a/cli/src/vite-plugin/index.js
+++ b/cli/src/vite-plugin/index.js
@@ -68,18 +68,7 @@ const plugin = (opts) => {
     },
     configureServer(server_) {
       server = server_
-      server.ws.on('connection', () => {
-        if (lastErrorSent) {
-          server.ws.send('elm:error', {
-            error: ElmErrorJson.toColoredHtmlOutput(lastErrorSent, {
-              GREEN: 'mediumseagreen',
-              RED: 'indianred',
-              BLUE: 'dodgerblue',
-            })
-          })
-        }
-      })
-      server.ws.on('elm:missing-error', () => {
+      server.ws.on('elm:client-ready', () => {
         if (lastErrorSent) {
           server.ws.send('elm:error', {
             error: ElmErrorJson.toColoredHtmlOutput(lastErrorSent, {

--- a/cli/src/vite-plugin/index.js
+++ b/cli/src/vite-plugin/index.js
@@ -79,6 +79,17 @@ const plugin = (opts) => {
           })
         }
       })
+      server.ws.on('elm:missing-error', () => {
+        if (lastErrorSent) {
+          server.ws.send('elm:error', {
+            error: ElmErrorJson.toColoredHtmlOutput(lastErrorSent, {
+              GREEN: 'mediumseagreen',
+              RED: 'indianred',
+              BLUE: 'dodgerblue',
+            })
+          })
+        }
+      })
     },
     async load(id) {
       const { valid, pathname, withParams } = parseImportId(id)


### PR DESCRIPTION
## Problem

When the elm-land client JS code connects to the server and there's a compiler error, in some cases the message for the compiler error is sent to the client before the client is ready to handle it. The client code detects the situation and tries to fix it by refreshing the page if there is no error or compiler output after a timeout, but the problem can happen again after the refresh.  For me, this meant up to 6 or so refreshes before the error appeared sometimes.

## Solution

Rather than the server sending messages to the client as soon as it connects, it waits for the client to send an `elm:client-ready event.  

## Notes

This was done in a few stages, so the first commit just replaces the refresh with a message that triggers a re-send of the error. I also made what I thought was a minor code tidying change while I was in there that I will call out below in case it was a mistake.
