### PR TITLE
:lady_beetle:  Bug Fix - Port not reading from environment variable

### DIFF
--- a/cli/src/commands/server.js
+++ b/cli/src/commands/server.js
@@ -17,6 +17,8 @@ let run = async () => {
     // TODO: Warn user about invalid config JSON
   }
 
+  let port = process.env.PORT || 1234
+
   return {
     message: ({ port }) => [
       '',
@@ -25,7 +27,7 @@ let run = async () => {
     files: [],
     effects: [
       { kind: 'generateHtml', config },
-      { kind: 'runServer', options: { port: 1234 } }
+      { kind: 'runServer', options: { port: port } }
     ]
   }
 }

--- a/cli/src/effects.js
+++ b/cli/src/effects.js
@@ -364,7 +364,7 @@ const generateHtml = async (config) => {
 let run = async (effects) => {
   // 1. Perform all effects, one at a time
   let results = []
-  let port = process.env.PORT || 1234
+  let port = undefined;
 
   for (let effect of effects) {
     switch (effect.kind) {


### PR DESCRIPTION
## Problem

There's a bit of a hidden feature where the PORT environment variable can be used to se the elm-land server port. However, it looks like a refactor at some point may have disconnected that logic from the port setup. This change links it all up.

## Solution

Moves the env check closer to the server set up, and makes sure it gets passed to vite. 
