### PR TITLE
🐞 Bug Fix – Elm binary isn't found for some users 

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -7,7 +7,7 @@
 
 Although this framework is still a work-in-progress, please feel free to tinker around until `v1.0.0` is released!
 
-Feedback is welcome anytime in the [Elm slack](https://elmlang.herokuapp.com/). Drop a comment in the `#elm-spa-users` channel and tag `@ryan` if you like!
+Feedback is welcome anytime in the [Incremental Elm Discord](https://discord.com/invite/Fwmn84xD?utm_source=Discord%20Widget&utm_medium=Connect). Come say hi in the `#elm-land` channel!
 
 ## Using the CLI
 
@@ -16,7 +16,7 @@ The `elm-land` CLI tool has everything you need to create your next Elm applicat
 ```
 $ elm-land
 
-🌈  Welcome to Elm Land! (v0.16.1)
+🌈  Welcome to Elm Land! (v0.16.3)
     ⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺
     Here are the available commands:
 

--- a/cli/package-lock.json
+++ b/cli/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "elm-land",
-  "version": "0.16.2",
+  "version": "0.16.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "elm-land",
-      "version": "0.16.1",
+      "version": "0.16.3",
       "license": "ISC",
       "dependencies": {
         "chokidar": "3.5.3",

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "elm-land",
-  "version": "0.16.2",
+  "version": "0.16.3",
   "description": "Reliable web apps for everyone",
   "main": "index.js",
   "bin": {

--- a/cli/tests/09-elm-binary.bats
+++ b/cli/tests/09-elm-binary.bats
@@ -80,7 +80,7 @@ load helpers
   cd ../examples/01-local-hello
   echo '{ "dependencies": { "elm-land": "file:../../cli/elm-land-0.16.3.tgz" } }' > package.json
   npm install -g pnpm
-  pnpm
+  pnpm install
 
   run npx elm-land build
   expectToPass

--- a/cli/tests/09-elm-binary.bats
+++ b/cli/tests/09-elm-binary.bats
@@ -22,6 +22,19 @@ load helpers
   cd ../../cli
 }
 
+@test "'elm-land build' should pass even if elm is globally installed with npm" {
+  npm link
+  npm install -g elm
+
+  cd ../examples/01-hello-world
+  run elm-land build
+  expectToPass
+
+  # Cleanup
+  rm -r .elm-land elm-stuff dist
+  cd ../../cli
+}
+
 @test "'elm-land build' should pass if elm-land is locally installed with npm" {
   npm rm -g elm-land
   npm pack

--- a/cli/tests/09-elm-binary.bats
+++ b/cli/tests/09-elm-binary.bats
@@ -1,0 +1,79 @@
+bats_require_minimum_version 1.5.0
+
+load helpers
+
+@test "'elm-land build' should fail if elm-land is not globally installed" {
+  npm rm -g elm-land
+
+  cd ../examples/01-hello-world
+  run -127 elm-land build
+  expectToFail
+}
+
+@test "'elm-land build' should pass if elm-land is globally installed with npm" {
+  npm link
+
+  cd ../examples/01-hello-world
+  run elm-land build
+  expectToPass
+
+  # Cleanup
+  rm -r .elm-land elm-stuff dist
+  cd ../../cli
+}
+
+@test "'elm-land build' should pass if elm-land is locally installed with npm" {
+  npm rm -g elm-land
+  npm pack
+
+  cp -r ../examples/01-hello-world ../examples/01-local-hello
+  cd ../examples/01-local-hello
+  echo '{ "dependencies": { "elm-land": "file:../../cli/elm-land-0.16.3.tgz" } }' > package.json
+  npm install
+
+  run npx elm-land build
+  expectToPass
+
+  # Cleanup
+  cd ..
+  rm -r 01-local-hello
+  cd ../cli
+}
+
+@test "'elm-land build' should pass if elm-land is locally installed with yarn" {
+  npm rm -g elm-land
+  npm pack
+
+  cp -r ../examples/01-hello-world ../examples/01-local-hello
+  cd ../examples/01-local-hello
+  echo '{ "dependencies": { "elm-land": "file:../../cli/elm-land-0.16.3.tgz" } }' > package.json
+  npm install -g yarn
+  yarn
+
+  run yarn elm-land build
+  expectToPass
+
+  # Cleanup
+  cd ..
+  rm -r 01-local-hello
+  cd ../cli
+}
+
+@test "'elm-land build' should pass if elm-land is locally installed with pnpm" {
+  npm rm -g elm-land
+  npm pack
+
+  cp -r ../examples/01-hello-world ../examples/01-local-hello
+  cd ../examples/01-local-hello
+  echo '{ "dependencies": { "elm-land": "file:../../cli/elm-land-0.16.3.tgz" } }' > package.json
+  npm install -g pnpm
+  pnpm
+
+  run npx elm-land build
+  expectToPass
+
+  # Cleanup
+  cd ..
+  rm -r 01-local-hello
+  cd ../cli
+}

--- a/cli/tests/helpers.bash
+++ b/cli/tests/helpers.bash
@@ -5,7 +5,7 @@ function expectToPass {
 }
 
 function expectToFail {
-  [ "$status" -eq 1 ]
+  [ "$status" -ne 0 ]
 }
 
 function expectFileExists {


### PR DESCRIPTION
## Problem

Users in the `#elm-land` discord channel have been reporting issues with the `elm` binary not being found when running `elm-land build` or `elm-land server`. 

@MattCheely had solved this problem for more users with PR #29, which accounts for local NPM installs– but @heyakyra still ran into problems when trying things out. They summarized the problem with this in issue #36!

## Solution

For this PR, I wanted to see where `yarn` and `pnpm` users had their CLI installed.

I tested for the presence of the Elm binary on the following paths:

1. `~/../node_modules/.bin/elm`
1. `~/../node_modules/elm/bin/elm`
1. `~/node_modules/.bin/elm`
1. `~/node_modules/elm/bin/elm`

For my machine (MacOS, Node v16.13.0), I learned that:
- The 2nd path was consistently available when `elm-land` was installed __locally__ ( in a `package.json`)
    - This was tested with `npm`, `yarn`, and `pnpm`
- The 4th path was consistently available when `elm-land` was installed __globally__ ( via `npm install -g`)
    - This was tested with `npm install -g`

I also added some tests to our `./cli/tests/` folder to see if this was true on different versions of Node, and to protect us against regressions in the future

## Notes

- Did not have a chance to test this on Windows– hoping we don't have any issues there!
