### PR TITLE
🐞 Bug Fix – Customizing the View module leads to errors

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -16,7 +16,7 @@ The `elm-land` CLI tool has everything you need to create your next Elm applicat
 ```
 $ elm-land
 
-🌈  Welcome to Elm Land! (v0.17.0)
+🌈  Welcome to Elm Land! (v0.17.1)
     ⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺
     Here are the available commands:
 

--- a/cli/package-lock.json
+++ b/cli/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "elm-land",
-  "version": "0.17.0",
+  "version": "0.17.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "elm-land",
-      "version": "0.17.0",
+      "version": "0.17.1",
       "license": "ISC",
       "dependencies": {
         "chokidar": "3.5.3",

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "elm-land",
-  "version": "0.17.0",
+  "version": "0.17.1",
   "description": "Reliable web apps for everyone",
   "main": "index.js",
   "bin": {

--- a/cli/src/codegen.js
+++ b/cli/src/codegen.js
@@ -1,3 +1,6 @@
+const path = require('path')
+const { Files } = require('./files')
+
 let generateElmLandFiles = async ({ pages, layouts }) => {
   let { Elm } = require('../dist/worker.js')
 
@@ -17,11 +20,18 @@ let generateElmLandFiles = async ({ pages, layouts }) => {
 let addNewPage = async ({ kind, url, filepath }) => {
   let { Elm } = require('../dist/worker.js')
 
+  let hasViewBeenCustomized = await Files.exists(path.join(process.cwd(), 'src', 'View.elm'))
+
   let newFiles = await new Promise((resolve, reject) => {
     let app = Elm.Worker.init({
       flags: {
         tag: 'add-page',
-        data: { kind, filepath, url }
+        data: {
+          hasViewBeenCustomized,
+          kind,
+          filepath,
+          url
+        }
       }
     })
     app.ports.onComplete.subscribe(resolve)

--- a/cli/src/codegen/src/Commands/Generate.elm
+++ b/cli/src/codegen/src/Commands/Generate.elm
@@ -81,7 +81,7 @@ mainElmModule data =
                             [ CodeGen.Expression.multilineRecord
                                 [ ( "init", CodeGen.Expression.value "init" )
                                 , ( "update", CodeGen.Expression.value "update" )
-                                , ( "view", CodeGen.Expression.value "view" )
+                                , ( "view", CodeGen.Expression.value "View.toBrowserDocument << view" )
                                 , ( "subscriptions", CodeGen.Expression.value "subscriptions" )
                                 , ( "onUrlChange", CodeGen.Expression.value "UrlChanged" )
                                 , ( "onUrlRequest", CodeGen.Expression.value "UrlRequested" )
@@ -439,7 +439,7 @@ mainElmModule data =
                 , annotation =
                     CodeGen.Annotation.function
                         [ CodeGen.Annotation.type_ "Model"
-                        , CodeGen.Annotation.type_ "Browser.Document Msg"
+                        , CodeGen.Annotation.type_ "View Msg"
                         ]
                 , arguments = [ CodeGen.Argument.new "model" ]
                 , expression = toViewCaseExpression data.pages

--- a/cli/src/templates/_elm-land/customizable/Pages/NotFound_.elm
+++ b/cli/src/templates/_elm-land/customizable/Pages/NotFound_.elm
@@ -1,11 +1,8 @@
 module Pages.NotFound_ exposing (page)
 
-import Html exposing (Html)
 import View exposing (View)
 
 
 page : View msg
 page =
-    { title = "404"
-    , body = [ Html.text "Page not found..." ]
-    }
+    View.fromString "Page not found."

--- a/cli/src/templates/_elm-land/customizable/View.elm
+++ b/cli/src/templates/_elm-land/customizable/View.elm
@@ -1,4 +1,16 @@
-module View exposing (View, map, none, toBrowserDocument)
+module View exposing
+    ( View, map
+    , none, fromString
+    , toBrowserDocument
+    )
+
+{-|
+
+@docs View, map
+@docs none, fromString
+@docs toBrowserDocument
+
+-}
 
 import Browser
 import Html
@@ -8,11 +20,16 @@ type alias View msg =
     Browser.Document msg
 
 
+{-| Used internally by Elm Land to create your application
+so it works with Elm's expected `Browser.Document msg` type.
+-}
 toBrowserDocument : View msg -> Browser.Document msg
 toBrowserDocument view =
     view
 
 
+{-| Used internally by Elm Land to wire up your pages together.
+-}
 map : (msg1 -> msg2) -> View msg1 -> View msg2
 map fn view =
     { title = view.title
@@ -20,8 +37,25 @@ map fn view =
     }
 
 
+{-| Used internally by Elm Land whenever transitioning between
+authenticated pages.
+-}
 none : View msg
 none =
     { title = ""
     , body = []
+    }
+
+
+{-| If you customize the `View` module, anytime you run `elm-land add page`,
+the generated page will use this when adding your `view` function.
+
+That way your app will compile after adding new pages, and you can see
+the new page working in the web browser!
+
+-}
+fromString : String -> View msg
+fromString moduleName =
+    { title = moduleName
+    , body = [ Html.text moduleName ]
     }

--- a/cli/tests/07-customize.bats
+++ b/cli/tests/07-customize.bats
@@ -62,6 +62,37 @@ load helpers
   rm -r tmp
 }
 
+@test "'elm-land add page' uses 'View.fromString' if the View module is customized" {
+
+  # Create a new project
+  mkdir -p tests/tmp
+  cd tests/tmp
+  run elm-land init hello-world
+  expectToPass
+  cd hello-world
+
+  # Generating a page before customizing View.elm
+  # should use the standard { title = "...", body = [...] }
+  run elm-land add page /test
+  expectFileExists "src/Pages/Test.elm"
+  expectFileContains "src/Pages/Test.elm" "{ title = "
+
+  # Customize the View module
+  run elm-land customize view
+  expectToPass
+  expectFileExists "src/View.elm"
+
+  # Generate a page after customizing View.elm
+  # should use the 'View.fromString' function defined by the user
+  run elm-land add page /test
+  expectFileExists "src/Pages/Test.elm"
+  expectFileContains "src/Pages/Test.elm" "View.fromString"
+
+  # Clean up tmp folder
+  cd ../..
+  rm -r tmp
+}
+
 @test "cleanup" {
   cleanupTmpFolder
 }

--- a/cli/tests/09-elm-binary.bats
+++ b/cli/tests/09-elm-binary.bats
@@ -41,7 +41,7 @@ load helpers
 
   cp -r ../examples/01-hello-world ../examples/01-local-hello
   cd ../examples/01-local-hello
-  echo '{ "dependencies": { "elm-land": "file:../../cli/elm-land-0.17.0.tgz" } }' > package.json
+  echo '{ "dependencies": { "elm-land": "file:../../cli/elm-land-0.17.1.tgz" } }' > package.json
   npm install
 
   run npx elm-land build
@@ -59,7 +59,7 @@ load helpers
 
   cp -r ../examples/01-hello-world ../examples/01-local-hello
   cd ../examples/01-local-hello
-  echo '{ "dependencies": { "elm-land": "file:../../cli/elm-land-0.17.0.tgz" } }' > package.json
+  echo '{ "dependencies": { "elm-land": "file:../../cli/elm-land-0.17.1.tgz" } }' > package.json
   npm install -g yarn
   yarn
 
@@ -78,7 +78,7 @@ load helpers
 
   cp -r ../examples/01-hello-world ../examples/01-local-hello
   cd ../examples/01-local-hello
-  echo '{ "dependencies": { "elm-land": "file:../../cli/elm-land-0.17.0.tgz" } }' > package.json
+  echo '{ "dependencies": { "elm-land": "file:../../cli/elm-land-0.17.1.tgz" } }' > package.json
   npm install -g pnpm
   pnpm install
 

--- a/cli/tests/helpers.bash
+++ b/cli/tests/helpers.bash
@@ -13,6 +13,11 @@ function expectFileExists {
   expectToPass
 }
 
+function expectFileDoesNotExist {
+  test ! -f $1
+  expectToPass
+}
+
 function expectOutputContains {
   [[ $output == *$1* ]]
 }

--- a/docs/.vitepress/config.js
+++ b/docs/.vitepress/config.js
@@ -1,4 +1,4 @@
-const version = '0.17.0'
+const version = '0.17.1'
 
 export default {
   title: 'Elm Land',


### PR DESCRIPTION
## Problem

If a user wants to use [Elm UI](https://package.elm-lang.org/packages/mdgriffith/elm-ui/latest), they run `elm-land customize view`, and a few things go wrong:
1. The code generated in `Main.elm` throws errors, because of a mismatch between `Browser.Document` and `View` 
1. Using `elm-land add page <url>` creates pages that don't compile (they still are using `Browser.Document`)
1. When running `elm-land server`, deleting the `src/View.elm` file does not automatically recreate the default `View.elm` file– meaning users need to restart their dev server when removing customized files.

## Solution

- Make updates to `Main.elm` so that things compile again!
- Listen for changes in customized files during `elm-land server`, to make sure things stay in sync!
- Customize how `elm-land add page` creates new `view` functions, without making the default experience confusing

## Notes

- I also added comments for each function in `View.elm` file for folks customizing things
- I had a hard time writing a BATS test to validate Problem 3 (recreating default files while dev server is running), would love to add one in
