### PR TITLE
:sparkles:  Feature - Support Redirects in Auth flow

### DIFF
--- a/cli/src/codegen/src/Commands/Generate.elm
+++ b/cli/src/codegen/src/Commands/Generate.elm
@@ -594,6 +594,14 @@ runWhenAuthenticatedDeclaration =
                               , arguments = [ CodeGen.Argument.new "user" ]
                               , expression = CodeGen.Expression.value "toTuple user"
                               }
+                            , { name = "Auth.Action.ShowLoadingPage"
+                              , arguments = [ CodeGen.Argument.new "loadingView" ]
+                              , expression =
+                                    CodeGen.Expression.multilineTuple
+                                        [ CodeGen.Expression.value "Loading loadingView"
+                                        , CodeGen.Expression.value "Cmd.none"
+                                        ]
+                              }
                             , { name = "Auth.Action.ReplaceRoute"
                               , arguments = [ CodeGen.Argument.new "options" ]
                               , expression =
@@ -610,20 +618,12 @@ runWhenAuthenticatedDeclaration =
                                         , CodeGen.Expression.value "toCmd (Effect.pushRoute options)"
                                         ]
                               }
-                            , { name = "Auth.Action.ExternalRedirect"
+                            , { name = "Auth.Action.LoadExternalUrl"
                               , arguments = [ CodeGen.Argument.new "url" ]
                               , expression =
                                     CodeGen.Expression.multilineTuple
                                         [ CodeGen.Expression.value "Redirecting"
                                         , CodeGen.Expression.value "toCmd (Effect.loadExternalUrl url)"
-                                        ]
-                              }
-                            , { name = "Auth.Action.ShowLoadingPage"
-                              , arguments = [ CodeGen.Argument.new "loadingView" ]
-                              , expression =
-                                    CodeGen.Expression.multilineTuple
-                                        [ CodeGen.Expression.value "Loading loadingView"
-                                        , CodeGen.Expression.value "Cmd.none"
                                         ]
                               }
                             ]

--- a/cli/src/codegen/src/Commands/Generate.elm
+++ b/cli/src/codegen/src/Commands/Generate.elm
@@ -610,6 +610,14 @@ runWhenAuthenticatedDeclaration =
                                         , CodeGen.Expression.value "toCmd (Effect.pushRoute options)"
                                         ]
                               }
+                            , { name = "Auth.Action.ExternalRedirect"
+                              , arguments = [ CodeGen.Argument.new "url" ]
+                              , expression =
+                                    CodeGen.Expression.multilineTuple
+                                        [ CodeGen.Expression.value "Redirecting"
+                                        , CodeGen.Expression.value "toCmd (Effect.loadExternalUrl url)"
+                                        ]
+                              }
                             , { name = "Auth.Action.ShowLoadingPage"
                               , arguments = [ CodeGen.Argument.new "loadingView" ]
                               , expression =

--- a/cli/src/templates/_elm-land/src/Auth/Action.elm
+++ b/cli/src/templates/_elm-land/src/Auth/Action.elm
@@ -1,13 +1,15 @@
 module Auth.Action exposing
     ( Action(..)
-    , loadPageWithUser, pushRoute, replaceRoute, showLoadingPage
+    , loadPageWithUser, showLoadingPage
+    , replaceRoute, pushRoute, loadExternalUrl
     , view, subscriptions
     )
 
 {-|
 
 @docs Action
-@docs loadPageWithUser, pushRoute, replaceRoute, showLoadingPage
+@docs loadPageWithUser, showLoadingPage
+@docs replaceRoute, pushRoute, loadExternalUrl
 
 @docs view, subscriptions
 
@@ -23,6 +25,7 @@ import View exposing (View)
 
 type Action user
     = LoadPageWithUser user
+    | ShowLoadingPage (View Never)
     | ReplaceRoute
         { path : Route.Path.Path
         , query : Dict String String
@@ -33,13 +36,17 @@ type Action user
         , query : Dict String String
         , hash : Maybe String
         }
-    | ExternalRedirect String
-    | ShowLoadingPage (View Never)
+    | LoadExternalUrl String
 
 
 loadPageWithUser : user -> Action user
 loadPageWithUser =
     LoadPageWithUser
+
+
+showLoadingPage : View Never -> Action user
+showLoadingPage =
+    ShowLoadingPage
 
 
 replaceRoute :
@@ -62,14 +69,9 @@ pushRoute =
     PushRoute
 
 
-externalRedirect : String -> Action user
-externalRedirect =
-    ExternalRedirect
-
-
-showLoadingPage : View Never -> Action user
-showLoadingPage =
-    ShowLoadingPage
+loadExternalUrl : String -> Action user
+loadExternalUrl =
+    LoadExternalUrl
 
 
 view : (user -> View msg) -> Action user -> View msg
@@ -78,24 +80,27 @@ view toView authAction =
         LoadPageWithUser user ->
             toView user
 
-        ReplaceRoute _ ->
-            View.none
-
-        PushRoute _ ->
-            View.none
-
-        ExternalRedirect _ ->
-            View.none
-
         ShowLoadingPage loadingView ->
             View.map never loadingView
 
+        ReplaceRoute _ ->
+            View.none
+
+        PushRoute _ ->
+            View.none
+
+        LoadExternalUrl _ ->
+            View.none
+
 
 subscriptions : (user -> Sub msg) -> Action user -> Sub msg
-subscriptions toView authAction =
+subscriptions toSubscriptions authAction =
     case authAction of
         LoadPageWithUser user ->
-            toView user
+            toSubscriptions user
+
+        ShowLoadingPage _ ->
+            Sub.none
 
         ReplaceRoute _ ->
             Sub.none
@@ -103,8 +108,5 @@ subscriptions toView authAction =
         PushRoute _ ->
             Sub.none
 
-        ExternalRedirect _ ->
-            Sub.none
-
-        ShowLoadingPage _ ->
+        LoadExternalUrl _ ->
             Sub.none

--- a/cli/src/templates/_elm-land/src/Auth/Action.elm
+++ b/cli/src/templates/_elm-land/src/Auth/Action.elm
@@ -33,6 +33,7 @@ type Action user
         , query : Dict String String
         , hash : Maybe String
         }
+    | ExternalRedirect String
     | ShowLoadingPage (View Never)
 
 
@@ -61,6 +62,11 @@ pushRoute =
     PushRoute
 
 
+externalRedirect : String -> Action user
+externalRedirect =
+    ExternalRedirect
+
+
 showLoadingPage : View Never -> Action user
 showLoadingPage =
     ShowLoadingPage
@@ -78,6 +84,9 @@ view toView authAction =
         PushRoute _ ->
             View.none
 
+        ExternalRedirect _ ->
+            View.none
+
         ShowLoadingPage loadingView ->
             View.map never loadingView
 
@@ -92,6 +101,9 @@ subscriptions toView authAction =
             Sub.none
 
         PushRoute _ ->
+            Sub.none
+
+        ExternalRedirect _ ->
             Sub.none
 
         ShowLoadingPage _ ->


### PR DESCRIPTION
## Problem

The `Auth.Action` type returned by `Auth.onPageLoad`

## Solution

This add a new `Auth.Action` variant: `ExternalRedirect` which will trigger the `loadExternalUrl` effect

## Notes

I didn't see a meaningful way to test this without getting into running elm program test or some other E2E thing on a generated app. If you have suggestions, I'd be happy to add something though. 
