### PR TITLE
🐞 Bug – `Shared.subscriptions` aren't working

### DIFF
--- a/docs/.vitepress/config.js
+++ b/docs/.vitepress/config.js
@@ -1,4 +1,4 @@
-const version = '0.17.1'
+const version = '0.17.2'
 
 export default {
   title: 'Elm Land',

--- a/projects/cli/README.md
+++ b/projects/cli/README.md
@@ -17,7 +17,7 @@ The `elm-land` CLI comes with everything you need to create your next web applic
 ```
 $ elm-land
 
-🌈  Welcome to Elm Land! (v0.17.1)
+🌈  Welcome to Elm Land! (v0.17.2)
     ⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺
     Here are the available commands:
 

--- a/projects/cli/package-lock.json
+++ b/projects/cli/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "elm-land",
-  "version": "0.17.1",
+  "version": "0.17.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "elm-land",
-      "version": "0.17.1",
+      "version": "0.17.2",
       "license": "ISC",
       "dependencies": {
         "chokidar": "3.5.3",

--- a/projects/cli/package.json
+++ b/projects/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "elm-land",
-  "version": "0.17.1",
+  "version": "0.17.2",
   "description": "Reliable web apps for everyone",
   "main": "index.js",
   "bin": {

--- a/projects/cli/src/codegen/src/Commands/Generate.elm
+++ b/projects/cli/src/codegen/src/Commands/Generate.elm
@@ -431,7 +431,34 @@ mainElmModule data =
                         , CodeGen.Annotation.type_ "Sub Msg"
                         ]
                 , arguments = [ CodeGen.Argument.new "model" ]
-                , expression = toSubscriptionPageCaseExpression data.pages
+                , expression =
+                    CodeGen.Expression.letIn
+                        { let_ =
+                            [ { argument = CodeGen.Argument.new "subscriptionsFromPage"
+                              , annotation = Just (CodeGen.Annotation.type_ "Sub Msg")
+                              , expression = toSubscriptionPageCaseExpression data.pages
+                              }
+                            ]
+                        , in_ =
+                            CodeGen.Expression.multilineFunction
+                                { name = "Sub.batch"
+                                , arguments =
+                                    [ CodeGen.Expression.multilineList
+                                        [ CodeGen.Expression.pipeline
+                                            [ CodeGen.Expression.function
+                                                { name = "Shared.subscriptions"
+                                                , arguments =
+                                                    [ CodeGen.Expression.parens [ CodeGen.Expression.value "Route.fromUrl () model.url" ]
+                                                    , CodeGen.Expression.value "model.shared"
+                                                    ]
+                                                }
+                                            , CodeGen.Expression.value "Sub.map SharedSent"
+                                            ]
+                                        , CodeGen.Expression.value "subscriptionsFromPage"
+                                        ]
+                                    ]
+                                }
+                        }
                 }
             , CodeGen.Declaration.comment [ "VIEW" ]
             , CodeGen.Declaration.function

--- a/projects/cli/tests/09-elm-binary.bats
+++ b/projects/cli/tests/09-elm-binary.bats
@@ -41,7 +41,7 @@ load helpers
 
   cp -r ../../examples/01-hello-world ../../examples/01-local-hello
   cd ../../examples/01-local-hello
-  echo '{ "dependencies": { "elm-land": "file:../../projects/cli/elm-land-0.17.1.tgz" } }' > package.json
+  echo '{ "dependencies": { "elm-land": "file:../../projects/cli/elm-land-0.17.2.tgz" } }' > package.json
   npm install
 
   run npx elm-land build
@@ -59,7 +59,7 @@ load helpers
 
   cp -r ../../examples/01-hello-world ../../examples/01-local-hello
   cd ../../examples/01-local-hello
-  echo '{ "dependencies": { "elm-land": "file:../../projects/cli/elm-land-0.17.1.tgz" } }' > package.json
+  echo '{ "dependencies": { "elm-land": "file:../../projects/cli/elm-land-0.17.2.tgz" } }' > package.json
   npm install -g yarn
   yarn
 
@@ -78,7 +78,7 @@ load helpers
 
   cp -r ../../examples/01-hello-world ../../examples/01-local-hello
   cd ../../examples/01-local-hello
-  echo '{ "dependencies": { "elm-land": "file:../../projects/cli/elm-land-0.17.1.tgz" } }' > package.json
+  echo '{ "dependencies": { "elm-land": "file:../../projects/cli/elm-land-0.17.2.tgz" } }' > package.json
   npm install -g pnpm
   pnpm install
 

--- a/projects/graphql/README.md
+++ b/projects/graphql/README.md
@@ -23,7 +23,7 @@ npm install -g elm-land@latest
 ```txt
 $ elm-land graphql
 
-🌈 Elm Land (v0.17.1) wants to add a plugin!
+🌈 Elm Land (v0.17.2) wants to add a plugin!
    ⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺
    To use the `@elm-land/graphql` plugin, I'll need
    to install the NPM package and add a bit of JSON
@@ -35,14 +35,14 @@ $ elm-land graphql
 ```txt
 $ elm-land graphql generate
 
-🌈  Elm Land (v0.17.1) successfully generated Elm files
+🌈  Elm Land (v0.17.2) successfully generated Elm files
     ⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺
 ```
 
 ```txt
 $ elm-land graphql watch
 
-🌈  Elm Land (v0.17.1) is watching "./graphql/*" for changes...
+🌈  Elm Land (v0.17.2) is watching "./graphql/*" for changes...
     ⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺
 ```
 

--- a/projects/graphql/package-lock.json
+++ b/projects/graphql/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@elm-land/graphql",
-  "version": "0.17.1",
+  "version": "0.17.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@elm-land/graphql",
-      "version": "0.17.1",
+      "version": "0.17.2",
       "license": "ISC",
       "dependencies": {
         "graphql": "16.6.0"

--- a/projects/graphql/package.json
+++ b/projects/graphql/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elm-land/graphql",
-  "version": "0.17.1",
+  "version": "0.17.2",
   "description": "Generate Elm code from GraphQL files",
   "main": "src/index.js",
   "scripts": {


### PR DESCRIPTION
## Problem

> What issue is this causing for Elm Land users?

Folks using the `Shared` module report that `subscriptions` aren't wired up! 🤦  ( See issue #42 )

For example, if a user tried to listen for window resize events via `Browser.Events.onResize` in their `Shared` module, those resize events would never be sent to their Elm application.

## Solution

> How does this code change address the problem described above?

In addition to wiring up the subscriptions from each page, I needed to add `Shared.subscriptions` in the codegen for the app's `Main` module.
