### PR TITLE
✨ Feature – Add support for external redirects during authentication

### DIFF
--- a/projects/cli/src/codegen/src/Commands/Generate.elm
+++ b/projects/cli/src/codegen/src/Commands/Generate.elm
@@ -645,7 +645,7 @@ runWhenAuthenticatedDeclaration =
                                         , CodeGen.Expression.value "toCmd (Effect.pushRoute options)"
                                         ]
                               }
-                            , { name = "Auth.Action.OpenExternalUrl"
+                            , { name = "Auth.Action.LoadExternalUrl"
                               , arguments = [ CodeGen.Argument.new "externalUrl" ]
                               , expression =
                                     CodeGen.Expression.multilineTuple

--- a/projects/cli/src/codegen/src/Commands/Generate.elm
+++ b/projects/cli/src/codegen/src/Commands/Generate.elm
@@ -621,6 +621,14 @@ runWhenAuthenticatedDeclaration =
                               , arguments = [ CodeGen.Argument.new "user" ]
                               , expression = CodeGen.Expression.value "toTuple user"
                               }
+                            , { name = "Auth.Action.ShowLoadingPage"
+                              , arguments = [ CodeGen.Argument.new "loadingView" ]
+                              , expression =
+                                    CodeGen.Expression.multilineTuple
+                                        [ CodeGen.Expression.value "Loading loadingView"
+                                        , CodeGen.Expression.value "Cmd.none"
+                                        ]
+                              }
                             , { name = "Auth.Action.ReplaceRoute"
                               , arguments = [ CodeGen.Argument.new "options" ]
                               , expression =
@@ -637,12 +645,12 @@ runWhenAuthenticatedDeclaration =
                                         , CodeGen.Expression.value "toCmd (Effect.pushRoute options)"
                                         ]
                               }
-                            , { name = "Auth.Action.ShowLoadingPage"
-                              , arguments = [ CodeGen.Argument.new "loadingView" ]
+                            , { name = "Auth.Action.OpenExternalUrl"
+                              , arguments = [ CodeGen.Argument.new "externalUrl" ]
                               , expression =
                                     CodeGen.Expression.multilineTuple
-                                        [ CodeGen.Expression.value "Loading loadingView"
-                                        , CodeGen.Expression.value "Cmd.none"
+                                        [ CodeGen.Expression.value "Redirecting"
+                                        , CodeGen.Expression.value "Browser.Navigation.load externalUrl"
                                         ]
                               }
                             ]

--- a/projects/cli/src/templates/_elm-land/src/Auth/Action.elm
+++ b/projects/cli/src/templates/_elm-land/src/Auth/Action.elm
@@ -1,13 +1,15 @@
 module Auth.Action exposing
     ( Action(..)
-    , loadPageWithUser, pushRoute, replaceRoute, showLoadingPage, openExternalUrl
+    , loadPageWithUser, showLoadingPage
+    , replaceRoute, pushRoute, loadExternalUrl
     , view, subscriptions
     )
 
 {-|
 
 @docs Action
-@docs loadPageWithUser, pushRoute, replaceRoute, showLoadingPage
+@docs loadPageWithUser, showLoadingPage
+@docs replaceRoute, pushRoute, loadExternalUrl
 
 @docs view, subscriptions
 
@@ -67,8 +69,8 @@ pushRoute =
     PushRoute
 
 
-openExternalUrl : String -> Action user
-openExternalUrl =
+loadExternalUrl : String -> Action user
+loadExternalUrl =
     LoadExternalUrl
 
 

--- a/projects/cli/src/templates/_elm-land/src/Auth/Action.elm
+++ b/projects/cli/src/templates/_elm-land/src/Auth/Action.elm
@@ -1,6 +1,6 @@
 module Auth.Action exposing
     ( Action(..)
-    , loadPageWithUser, pushRoute, replaceRoute, showLoadingPage
+    , loadPageWithUser, pushRoute, replaceRoute, showLoadingPage, openExternalUrl
     , view, subscriptions
     )
 
@@ -23,6 +23,7 @@ import View exposing (View)
 
 type Action user
     = LoadPageWithUser user
+    | ShowLoadingPage (View Never)
     | ReplaceRoute
         { path : Route.Path.Path
         , query : Dict String String
@@ -33,12 +34,17 @@ type Action user
         , query : Dict String String
         , hash : Maybe String
         }
-    | ShowLoadingPage (View Never)
+    | OpenExternalUrl String
 
 
 loadPageWithUser : user -> Action user
 loadPageWithUser =
     LoadPageWithUser
+
+
+showLoadingPage : View Never -> Action user
+showLoadingPage =
+    ShowLoadingPage
 
 
 replaceRoute :
@@ -61,9 +67,9 @@ pushRoute =
     PushRoute
 
 
-showLoadingPage : View Never -> Action user
-showLoadingPage =
-    ShowLoadingPage
+openExternalUrl : String -> Action user
+openExternalUrl =
+    OpenExternalUrl
 
 
 view : (user -> View msg) -> Action user -> View msg
@@ -72,14 +78,17 @@ view toView authAction =
         LoadPageWithUser user ->
             toView user
 
+        ShowLoadingPage loadingView ->
+            View.map never loadingView
+
         ReplaceRoute _ ->
             View.none
 
         PushRoute _ ->
             View.none
 
-        ShowLoadingPage loadingView ->
-            View.map never loadingView
+        OpenExternalUrl _ ->
+            View.none
 
 
 subscriptions : (user -> Sub msg) -> Action user -> Sub msg
@@ -88,11 +97,14 @@ subscriptions toView authAction =
         LoadPageWithUser user ->
             toView user
 
+        ShowLoadingPage _ ->
+            Sub.none
+
         ReplaceRoute _ ->
             Sub.none
 
         PushRoute _ ->
             Sub.none
 
-        ShowLoadingPage _ ->
+        OpenExternalUrl _ ->
             Sub.none

--- a/projects/cli/src/templates/_elm-land/src/Auth/Action.elm
+++ b/projects/cli/src/templates/_elm-land/src/Auth/Action.elm
@@ -34,7 +34,7 @@ type Action user
         , query : Dict String String
         , hash : Maybe String
         }
-    | OpenExternalUrl String
+    | LoadExternalUrl String
 
 
 loadPageWithUser : user -> Action user
@@ -69,7 +69,7 @@ pushRoute =
 
 openExternalUrl : String -> Action user
 openExternalUrl =
-    OpenExternalUrl
+    LoadExternalUrl
 
 
 view : (user -> View msg) -> Action user -> View msg
@@ -87,7 +87,7 @@ view toView authAction =
         PushRoute _ ->
             View.none
 
-        OpenExternalUrl _ ->
+        LoadExternalUrl _ ->
             View.none
 
 
@@ -106,5 +106,5 @@ subscriptions toView authAction =
         PushRoute _ ->
             Sub.none
 
-        OpenExternalUrl _ ->
+        LoadExternalUrl _ ->
             Sub.none


### PR DESCRIPTION
## Problem

@MattCheely pointed out that it is useful to redirect to external URLs during the authentication process, rather than just internal application routes.

( I think this feature will be critical for OAuth flows! )

## Solution

- Use Matt's code changes for #41 , but handle the annoying merge conflicts I caused him with the new repo structure ( i moved `src/cli/*` into `projects/cli/*` )
- Rename `ExternalRedirect` to `LoadExternalUrl` to be consistent with `Effect.loadExternalUrl`

## Notes

( Matt secretly gets full credit for this feature, I just handled the merge conflict! 😅 )
