### PR TITLE
:lady_beetle: Bug fix - `add layout` can create modules that don't compile.

### DIFF
--- a/projects/cli/src/commands/add.js
+++ b/projects/cli/src/commands/add.js
@@ -22,6 +22,24 @@ let addNewLayout = (kind) => async ([name]) => {
   if (!inFolderWithElmLandJson) {
     return Promise.reject(Utils.notInElmLandProject)
   }
+  
+  // Capitalize the name if needed
+  if (name.match(/^[a-z]/)) {
+    name = name[0].toUpperCase() + name.slice(1);
+  }
+  
+  if (!name.match(/[A-Z][a-zA-Z0-9]*/)) {
+    return Promise.reject([
+      '',
+      Utils.intro.error('couldn\'t create a layout with that name'),
+      '    Layout names need to start with a letter, and can only contain letters and numbers',
+      '',
+      '    Here are some examples:',
+      '',
+      `    elm-land add ${kind === 'new' ? 'layout' : `layout:${kind}`} ${Terminal.pink(`Sidebar`)}`,
+      `    elm-land add ${kind === 'new' ? 'layout' : `layout:${kind}`} ${Terminal.pink(`HeaderWithTabs`)}`,
+    ].join('\n'))
+  }
 
   let [generatedFile] = await Codegen.addNewLayout({
     kind,

--- a/projects/cli/tests/05-add-layout.bats
+++ b/projects/cli/tests/05-add-layout.bats
@@ -10,6 +10,24 @@ load helpers
   expectOutputContains "elm-land add layout:static"
 }
 
+@test "'elm-land add layout:static 1234' fails with a bad name" {
+  mkdir -p tests/tmp
+  cd tests/tmp
+  
+  run elm-land init hello-world
+  cd hello-world
+
+  run elm-land add layout:static 1234
+  expectToFail
+
+  expectOutputContains "Layout names need to start with"
+  expectOutputContains "Here are some examples:"
+  expectOutputContains "elm-land add layout:static"
+
+  cd ../..
+  rm -r tmp
+}
+
 @test "'elm-land add layout:static Sidebar' creates a Sidebar layout" {
   mkdir -p tests/tmp
   cd tests/tmp
@@ -26,6 +44,25 @@ load helpers
   expectFileExists "src/Layouts/Sidebar.elm"
   expectFileContains "src/Layouts/Sidebar.elm" "module Layouts.Sidebar exposing (layout)"
   expectFileContains "src/Layouts/Sidebar.elm" "layout : { page : View msg } -> View msg"
+
+  cd ../..
+  rm -r tmp
+}
+
+@test "lowercase layout names are automatically capitalized" {
+  mkdir -p tests/tmp
+  cd tests/tmp
+  
+  run elm-land init hello-world
+  cd hello-world
+
+  run elm-land add layout:static lowercase
+  expectToPass
+
+  expectOutputContains "added a new layout"
+  expectOutputContains "./src/Layouts/Lowercase.elm"
+
+  expectFileExists "src/Layouts/Lowercase.elm"
 
   cd ../..
   rm -r tmp


### PR DESCRIPTION
## Problem

When creating a layout, it is possible to request an invalid module name and end up with a module that won't compile. For example:

`elm-land add layout:static lowercase`

will create a module called `layout.elm` which cannot compile because modules must begin with an uppercase letter

## Solution

This adds checks to the `add` command that automatically upper-cases a lowercase initial letter, and rejects other invalid names with a friendly error message.

