### PR TITLE
🧹 Chore - Change default host to 0.0.0.0

### DIFF
--- a/docs/.vitepress/config.js
+++ b/docs/.vitepress/config.js
@@ -1,4 +1,4 @@
-const version = '0.17.2'
+const version = '0.17.3'
 
 export default {
   title: 'Elm Land',

--- a/projects/cli/README.md
+++ b/projects/cli/README.md
@@ -17,7 +17,7 @@ The `elm-land` CLI comes with everything you need to create your next web applic
 ```
 $ elm-land
 
-🌈  Welcome to Elm Land! (v0.17.2)
+🌈  Welcome to Elm Land! (v0.17.3)
     ⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺
     Here are the available commands:
 

--- a/projects/cli/package-lock.json
+++ b/projects/cli/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "elm-land",
-  "version": "0.17.2",
+  "version": "0.17.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "elm-land",
-      "version": "0.17.2",
+      "version": "0.17.3",
       "license": "ISC",
       "dependencies": {
         "chokidar": "3.5.3",

--- a/projects/cli/package.json
+++ b/projects/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "elm-land",
-  "version": "0.17.2",
+  "version": "0.17.3",
   "description": "Reliable web apps for everyone",
   "main": "index.js",
   "bin": {

--- a/projects/cli/src/commands/server.js
+++ b/projects/cli/src/commands/server.js
@@ -18,16 +18,19 @@ let run = async () => {
   }
 
   let port = process.env.PORT || 1234
+  let host = process.env.HOST || '0.0.0.0'
+
+  let formattedHost = host === '0.0.0.0' ? 'localhost' : host
 
   return {
     message: ({ port }) => [
       '',
-      Utils.intro.success(`is ready at http://localhost:${port}`)
+      Utils.intro.success(`is ready at http://${formattedHost}:${port}`)
     ].join('\n'),
     files: [],
     effects: [
       { kind: 'generateHtml', config },
-      { kind: 'runServer', options: { port: port } }
+      { kind: 'runServer', options: { host, port } }
     ]
   }
 }

--- a/projects/cli/src/effects.js
+++ b/projects/cli/src/effects.js
@@ -112,6 +112,7 @@ let runServer = async (options) => {
       root: path.join(process.cwd(), '.elm-land', 'server'),
       publicDir: path.join(process.cwd(), 'static'),
       server: {
+        host: '0.0.0.0',
         port: options.port,
         fs: { allow: ['../..'] }
       },

--- a/projects/cli/src/effects.js
+++ b/projects/cli/src/effects.js
@@ -112,7 +112,7 @@ let runServer = async (options) => {
       root: path.join(process.cwd(), '.elm-land', 'server'),
       publicDir: path.join(process.cwd(), 'static'),
       server: {
-        host: '0.0.0.0',
+        host: options.host,
         port: options.port,
         fs: { allow: ['../..'] }
       },

--- a/projects/cli/tests/09-elm-binary.bats
+++ b/projects/cli/tests/09-elm-binary.bats
@@ -41,7 +41,7 @@ load helpers
 
   cp -r ../../examples/01-hello-world ../../examples/01-local-hello
   cd ../../examples/01-local-hello
-  echo '{ "dependencies": { "elm-land": "file:../../projects/cli/elm-land-0.17.2.tgz" } }' > package.json
+  echo '{ "dependencies": { "elm-land": "file:../../projects/cli/elm-land-0.17.3.tgz" } }' > package.json
   npm install
 
   run npx elm-land build
@@ -59,7 +59,7 @@ load helpers
 
   cp -r ../../examples/01-hello-world ../../examples/01-local-hello
   cd ../../examples/01-local-hello
-  echo '{ "dependencies": { "elm-land": "file:../../projects/cli/elm-land-0.17.2.tgz" } }' > package.json
+  echo '{ "dependencies": { "elm-land": "file:../../projects/cli/elm-land-0.17.3.tgz" } }' > package.json
   npm install -g yarn
   yarn
 
@@ -78,7 +78,7 @@ load helpers
 
   cp -r ../../examples/01-hello-world ../../examples/01-local-hello
   cd ../../examples/01-local-hello
-  echo '{ "dependencies": { "elm-land": "file:../../projects/cli/elm-land-0.17.2.tgz" } }' > package.json
+  echo '{ "dependencies": { "elm-land": "file:../../projects/cli/elm-land-0.17.3.tgz" } }' > package.json
   npm install -g pnpm
   pnpm install
 

--- a/projects/graphql/README.md
+++ b/projects/graphql/README.md
@@ -23,7 +23,7 @@ npm install -g elm-land@latest
 ```txt
 $ elm-land graphql
 
-🌈 Elm Land (v0.17.2) wants to add a plugin!
+🌈 Elm Land (v0.17.3) wants to add a plugin!
    ⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺
    To use the `@elm-land/graphql` plugin, I'll need
    to install the NPM package and add a bit of JSON
@@ -35,14 +35,14 @@ $ elm-land graphql
 ```txt
 $ elm-land graphql build
 
-🌈  Elm Land (v0.17.2) successfully generated Elm files
+🌈  Elm Land (v0.17.3) successfully generated Elm files
     ⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺
 ```
 
 ```txt
 $ elm-land graphql watch
 
-🌈  Elm Land (v0.17.2) is watching "./graphql/*" for changes...
+🌈  Elm Land (v0.17.3) is watching "./graphql/*" for changes...
     ⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺
 ```
 
@@ -55,7 +55,7 @@ Here’s what running the CLI looks like when there’s no schema provided:
 ```
 $ elm-land graphql build
 
-🌈 Elm Land (v0.17.2) needs a GraphQL schema
+🌈 Elm Land (v0.17.3) needs a GraphQL schema
    ‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾
    You can provide one by customizing the "elm-land.json"
    file to include a "graphql.schema" field.

--- a/projects/graphql/package-lock.json
+++ b/projects/graphql/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@elm-land/graphql",
-  "version": "0.17.2",
+  "version": "0.17.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@elm-land/graphql",
-      "version": "0.17.2",
+      "version": "0.17.3",
       "license": "ISC",
       "dependencies": {
         "graphql": "16.6.0"

--- a/projects/graphql/package.json
+++ b/projects/graphql/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elm-land/graphql",
-  "version": "0.17.2",
+  "version": "0.17.3",
   "description": "Generate Elm code from GraphQL files",
   "main": "src/index.js",
   "scripts": {


### PR DESCRIPTION
## Problem

> What issue is this causing for Elm Land users?

Folks in the [Elm Land Discord](https://join.elm.land/) are sometimes working in environments like Docker where the host needs to be `0.0.0.0`, or their web server won't be available in the local browser.

Elm Land doesn't support any options for changing the `HOST` when running the `elm-land server` command.

## Solution

> How does this code change address the problem described above?

- Rather than asking these users to look up how to customize the hostname, I've set `0.0.0.0` as the default for `elm-land server`
- This can be overridden with `HOST=localhost elm-land server`, but that isn't documented anywhere yet

