### PR TITLE
Add script tags to the end of the generated index.html

### DIFF
--- a/docs/guide/pages-and-layouts.md
+++ b/docs/guide/pages-and-layouts.md
@@ -416,7 +416,8 @@ We can add `<link>` tags to our HTML by updating the `app.html.link` property li
       ],
       "link": [
         { "rel": "stylesheet", "href": "/styles.css" }
-      ]
+      ],
+      "script": []
     }
   }
 }

--- a/docs/guide/rest-apis.md
+++ b/docs/guide/rest-apis.md
@@ -564,7 +564,8 @@ Now that we have all 150 Pokemon, we can render them in a grid layout. Let's use
       // ...
       "link": [
         { "rel": "stylesheet", "href": "https://cdn.jsdelivr.net/npm/bulma@0.9.4/css/bulma.min.css" }
-      ]
+      ],
+      // ...
     }
   }
 }

--- a/docs/guide/user-auth.md
+++ b/docs/guide/user-auth.md
@@ -59,6 +59,7 @@ We can add the Bulma CSS by editing the `./elm-land.json` file at the root of th
       "link": [
         { "rel": "stylesheet", "href": "https://cdn.jsdelivr.net/npm/bulma@0.9.4/css/bulma.min.css" }
       ]
+      ...
     }
   }
 }

--- a/examples/01-hello-world/elm-land.json
+++ b/examples/01-hello-world/elm-land.json
@@ -13,7 +13,8 @@
         { "http-equiv": "X-UA-Compatible", "content": "IE=edge" },
         { "name": "viewport", "content": "width=device-width, initial-scale=1.0" }
       ],
-      "link": []
+      "link": [],
+      "script": []
     }
   }
 }

--- a/examples/02-pages-and-layouts/elm-land.json
+++ b/examples/02-pages-and-layouts/elm-land.json
@@ -15,7 +15,8 @@
       ],
       "link": [
         { "rel": "stylesheet", "href": "/styles.css" }
-      ]
+      ],
+      "script": []
     }
   }
 }

--- a/examples/03-user-input/elm-land.json
+++ b/examples/03-user-input/elm-land.json
@@ -13,7 +13,8 @@
         { "http-equiv": "X-UA-Compatible", "content": "IE=edge" },
         { "name": "viewport", "content": "width=device-width, initial-scale=1.0" }
       ],
-      "link": []
+      "link": [],
+      "script": []
     }
   }
 }

--- a/examples/04-rest-apis/elm-land.json
+++ b/examples/04-rest-apis/elm-land.json
@@ -19,7 +19,8 @@
       ],
       "link": [
         { "rel": "stylesheet", "href": "https://cdn.jsdelivr.net/npm/bulma@0.9.4/css/bulma.min.css" }
-      ]
+      ],
+      "script": []
     }
   }
 }

--- a/examples/05-user-auth/elm-land.json
+++ b/examples/05-user-auth/elm-land.json
@@ -19,7 +19,8 @@
       ],
       "link": [
         { "rel": "stylesheet", "href": "https://cdn.jsdelivr.net/npm/bulma@0.9.4/css/bulma.min.css" }
-      ]
+      ],
+      "script": []
     }
   }
 }

--- a/examples/06-query-parameters/elm-land.json
+++ b/examples/06-query-parameters/elm-land.json
@@ -21,7 +21,8 @@
         { "rel": "icon", "href": "/favicon.png" },
         { "rel": "stylesheet", "href": "https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.9.0/css/all.min.css" },
         { "rel": "stylesheet", "href": "https://cdn.jsdelivr.net/npm/bulma@0.9.4/css/bulma.min.css" }
-      ]
+      ],
+      "script": []
     }
   }
 }

--- a/projects/cli/src/effects.js
+++ b/projects/cli/src/effects.js
@@ -339,6 +339,14 @@ const generateHtml = async (config) => {
     return `<${tagName}${toAttributeString(attrs)}>${child}</${tagName}>`
   }
 
+  let toHtmlTags = (tagName, tags) => {
+    return tags.map(attrs =>
+      Object.keys(attrs).length > 0
+        ? `<${tagName}${toAttributeString(attrs)}></${tagName}>`
+        : ''
+    )
+  }
+
   let toSelfClosingHtmlTags = (tagName, tags = []) => {
     return tags.map(attrs =>
       Object.keys(attrs).length > 0
@@ -352,8 +360,9 @@ const generateHtml = async (config) => {
     : []
   let metaTags = toSelfClosingHtmlTags('meta', attempt(_ => config.app.html.meta))
   let linkTags = toSelfClosingHtmlTags('link', attempt(_ => config.app.html.link))
+  let scriptTags = toHtmlTags('script', attempt(_ => config.app.html.script))
 
-  let combinedTags = [...titleTags, ...metaTags, ...linkTags]
+  let combinedTags = [...titleTags, ...metaTags, ...linkTags, ...scriptTags]
   let headTags = combinedTags.length > 0
     ? '\n    ' + combinedTags.join('\n    ') + '\n  '
     : ''

--- a/projects/cli/src/templates/elm-land.json
+++ b/projects/cli/src/templates/elm-land.json
@@ -17,7 +17,8 @@
         { "http-equiv": "X-UA-Compatible", "content": "IE=edge" },
         { "name": "viewport", "content": "width=device-width, initial-scale=1.0" }
       ],
-      "link": []
+      "link": [],
+      "script": []
     }
   }
 }


### PR DESCRIPTION
## Problem

Users are unable to include URL scripts in their index.html (like scripts delivered from a CDN, or polyfills). This also means no setup code can be run before the Elm app is initialised.

## Solution

Adds a `script` field to the `elm-land.json` config file that adds the specified script tags in to the generated HTML.

Closes https://github.com/elm-land/elm-land/issues/49
