### PR TITLE
Add missing link to elm-land CLI on NPM

### DIFF
--- a/docs/guide/config/cli-commands.md
+++ b/docs/guide/config/cli-commands.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-The [Elm Land CLI] tool is available via NPM. This one command-line tool has everything you need
+The [Elm Land CLI](https://www.npmjs.com/package/elm-land) tool is available via NPM. This one command-line tool has everything you need
 to create new projects, run your development server, and even build your application for production.
 
 After installing, you can run `elm-land --help` to see these commands at any time. This page is a more


### PR DESCRIPTION
## Problem

Markdown at https://elm.land/guide/config/cli-commands.html appears to be missing a link to NPM

## Solution

Adds the missing link

## Notes
