### PR TITLE
use new Date because Date.now() is in milliseconds, fixes #61

### DIFF
--- a/projects/cli/src/files.js
+++ b/projects/cli/src/files.js
@@ -156,7 +156,7 @@ let readFromUserFolder = async (filepath) => {
 
 // Pokes a file to trigger any related file-watchers
 let touch = (filepath) => {
-  let now = Date.now()
+  let now = new Date()
   fs.utimesSync(filepath, now, now)
 }
 


### PR DESCRIPTION
## Notes

fixes #61
