### PR TITLE
use vite-plugin-rewrite-all to allow dots in paths

### DIFF
--- a/projects/cli/package.json
+++ b/projects/cli/package.json
@@ -41,7 +41,6 @@
     "node-elm-compiler": "5.0.6",
     "terser": "5.15.1",
     "typescript": "4.9.3",
-    "vite": "3.2.5",
-    "vite-plugin-rewrite-all": "^1.0.1"
+    "vite": "3.2.5"
   }
 }

--- a/projects/cli/package.json
+++ b/projects/cli/package.json
@@ -41,6 +41,7 @@
     "node-elm-compiler": "5.0.6",
     "terser": "5.15.1",
     "typescript": "4.9.3",
-    "vite": "3.2.5"
+    "vite": "3.2.5",
+    "vite-plugin-rewrite-all": "^1.0.1"
   }
 }

--- a/projects/cli/src/effects.js
+++ b/projects/cli/src/effects.js
@@ -150,7 +150,7 @@ let runServer = async (options) => {
         fs: { allow: ['../..'] }
       },
       plugins: [
-        RewriteAllPlugin.default(),
+        DotPathFixPlugin.plugin(),
         ElmVitePlugin.plugin({
           debug,
           optimize: false

--- a/projects/cli/src/effects.js
+++ b/projects/cli/src/effects.js
@@ -3,6 +3,7 @@ const path = require('path')
 const Vite = require('vite')
 const ElmVitePlugin = require('./vite-plugins/elm/index.js')
 const TypeScriptPlugin = require('./vite-plugins/typescript/index.js')
+const RewriteAllPlugin = require('vite-plugin-rewrite-all')
 const { Codegen } = require('./codegen')
 const { Files } = require('./files')
 const { Utils, Terminal } = require('./commands/_utils')
@@ -149,6 +150,7 @@ let runServer = async (options) => {
         fs: { allow: ['../..'] }
       },
       plugins: [
+        RewriteAllPlugin.default(),
         ElmVitePlugin.plugin({
           debug,
           optimize: false

--- a/projects/cli/src/vite-plugins/dot-path-fix/index.js
+++ b/projects/cli/src/vite-plugins/dot-path-fix/index.js
@@ -1,0 +1,25 @@
+const fs = require('fs')
+
+const plugin = () => {
+    return {
+        name: 'dot-path-fix-plugin',
+        configureServer: (server) => {
+            server.middlewares.use((req, _, next) => {
+                const reqPath = req.url.split('?', 2)[0];
+                if (reqPath == '/main.js') {
+                    next()
+                } else {
+                    if (!req.url.startsWith('/@') && !fs.existsSync(`.${reqPath}`)) {
+                        console.log(reqPath, 'redir to /')
+                        req.url = '/';
+                    }
+                    next();
+                }
+            });
+        }
+    }
+};
+
+module.exports = {
+    plugin
+}


### PR DESCRIPTION
## Problem

When using dynamic route params that result in dots in the path, the dev-server returns a 404 upon refresh (F5) of the page

## Solution

Using the provided plugin, this seems to no longer be a problem

## Notes

https://github.com/vitejs/vite/issues/2415

also: needs to be tested!