### PR TITLE
Expose Vites's server proxy options

### DIFF
--- a/docs/guide/config/elm-land-json.md
+++ b/docs/guide/config/elm-land-json.md
@@ -32,6 +32,11 @@ For reference, here is the default `elm-land.json` file that is created with eve
       "link": [],
       "script": []
     },
+    "server": {
+      "proxy": {
+        "/api": "http://localhost:5000/"
+      }
+    },
     "router": {
       "useHashRouting": false
     }
@@ -473,6 +478,15 @@ __Output:__ `index.html`
 ```
 
 :::
+## app.server.proxy
+
+::: info TYPE
+```elm
+{ proxy : Record<string, string | ProxyOptions> }
+```
+:::
+
+Configure custom proxy rules for the dev server. Expects an object of { key: options } pairs. See https://vitejs.dev/config/server-options.html#server-proxy for examples. 
 
 ## app.router
 

--- a/examples/05-user-auth/elm-land.json
+++ b/examples/05-user-auth/elm-land.json
@@ -21,6 +21,11 @@
       ],
       "script": []
     },
+    "server": {
+      "proxy": {
+        "/api": "http://localhost:5000/"
+      }
+    },
     "router": {
       "useHashRouting": false
     }

--- a/projects/cli/src/commands/server.js
+++ b/projects/cli/src/commands/server.js
@@ -36,9 +36,9 @@ let run = async () => {
     // TODO: Warn user about invalid config JSON
   }
 
-  let port = process.env.PORT || 1234
-  let host = process.env.HOST || '0.0.0.0'
-  let proxy = config?.server?.proxy || {}
+  let port = process.env.PORT || (config?.app?.server?.port || 1234)
+  let host = process.env.HOST || (config?.app?.server?.host || '0.0.0.0')
+  let proxy = config?.app?.server?.proxy || {}
   let formattedHost = host === '0.0.0.0' ? 'localhost' : host
 
   return {

--- a/projects/cli/src/commands/server.js
+++ b/projects/cli/src/commands/server.js
@@ -38,7 +38,7 @@ let run = async () => {
 
   let port = process.env.PORT || 1234
   let host = process.env.HOST || '0.0.0.0'
-
+  let proxy = config?.server?.proxy || {}
   let formattedHost = host === '0.0.0.0' ? 'localhost' : host
 
   return {
@@ -49,7 +49,7 @@ let run = async () => {
     files: [],
     effects: [
       { kind: 'generateHtml', config },
-      { kind: 'runServer', options: { host, port } }
+      { kind: 'runServer', options: { host, port, proxy } }
     ]
   }
 }

--- a/projects/cli/src/effects.js
+++ b/projects/cli/src/effects.js
@@ -146,7 +146,8 @@ let runServer = async (options) => {
       server: {
         host: options.host,
         port: options.port,
-        fs: { allow: ['../..'] }
+        fs: { allow: ['../..'] },
+        proxy: options.proxy
       },
       plugins: [
         ElmVitePlugin.plugin({


### PR DESCRIPTION
## Problem

It's annoying to have parts of API and mocks on different hosts. With proxy, one can mirror live app config.

## Solution

Expose Vite Server proxy options, for seamless integration.

## Notes

> (Can be blank!) Are there any unrelated code changes or other notes you'd like to share regarding this PR?
