### PR TITLE
Check for existance of files in publicDir as well

### DIFF
--- a/projects/cli/src/vite-plugins/dot-path-fix/index.js
+++ b/projects/cli/src/vite-plugins/dot-path-fix/index.js
@@ -1,4 +1,5 @@
 const fs = require('fs')
+const path = require('path')
 
 const plugin = () => {
     return {
@@ -9,7 +10,7 @@ const plugin = () => {
                 if (reqPath == '/main.js') {
                     next()
                 } else {
-                    if (!req.url.startsWith('/@') && !fs.existsSync(`.${reqPath}`)) {
+                    if (!req.url.startsWith('/@') && !fs.existsSync(`.${reqPath}`) && !fs.existsSync(path.join(server.config.publicDir, reqPath))) {
                         req.url = '/';
                     }
                     next();


### PR DESCRIPTION
## Problem

> The DotPathFix-Plugin redirected to / for requests to existing static assets

## Solution

> Check if the file exists in the publicDir, and if so, prevent rewriting the request-url
