### PR TITLE
:lady_beetle: Bug Fix - Top-level catch-all routes won't compile

### DIFF
--- a/projects/cli/src/codegen/src/Commands/Generate.elm
+++ b/projects/cli/src/codegen/src/Commands/Generate.elm
@@ -2173,7 +2173,9 @@ routePathFromStringExpression { pages } =
                 { value = CodeGen.Argument.new "urlPathSegments"
                 , branches =
                     if List.any PageFile.isTopLevelCatchAllPage pages then
-                        List.map toBranch pages
+                        pages
+                            |> List.filter (\page -> not (PageFile.isNotFoundPage page))
+                            |> List.map toBranch
 
                     else
                         List.map toBranch pages ++ [ nothingBranch ]

--- a/projects/cli/tests/06-build.bats
+++ b/projects/cli/tests/06-build.bats
@@ -27,6 +27,21 @@ load helpers
   cd ../../projects/cli
 }
 
+@test "'elm-land build' still works after creating a top-level catch-all page" {
+  cd ../../examples/01-hello-world
+
+  run elm-land add page "/*"
+  expectToPass
+
+  run elm-land build
+  expectToPass
+
+  expectOutputContains "successfully built"
+
+  rm -r .elm-land elm-stuff dist src/Pages/ALL_.elm
+  cd ../../projects/cli
+}
+
 @test "cleanup" {
   cleanupTmpFolder
 }


### PR DESCRIPTION
## Problem

If an app had a top-level catch-all page, it couldn't build because of overlap in case-statements between the catch-all page and the generated not-found page.

## Solution

 This change excludes the not-found page path from URL parsing if a top-level catch-all page exists.
