### PR TITLE
Add autocomplete attribute to resolve console warning

### DIFF
--- a/examples/05-user-auth/src/Pages/SignIn.elm
+++ b/examples/05-user-auth/src/Pages/SignIn.elm
@@ -197,6 +197,7 @@ viewFormInput options =
                     [ ( "is-danger", options.error /= Nothing )
                     ]
                 , Attr.type_ (fromFieldToInputType options.field)
+                , Attr.autocomplete True
                 , Attr.value options.value
                 , Html.Events.onInput (UserUpdatedInput options.field)
                 ]


### PR DESCRIPTION
## Problem

> What issue is this causing for Elm Land users?

Currently, the following warning is shown in the dev console:

<img width="644" alt="Screen Shot 2023-04-15 at 12 24 29 AM" src="https://user-images.githubusercontent.com/6151409/232182772-0e18f3e2-8054-4294-8e6d-f5b9b0575eaf.png">

## Solution

> How does this code change address the problem described above?

Adding an `autocomplete` attribute resolves the console warning.

## Notes

> (Can be blank!) Are there any unrelated code changes or other notes you'd like to share regarding this PR?

N/A
