### PR TITLE
Add missing 'style' import

### DIFF
--- a/docs/guide/user-auth.md
+++ b/docs/guide/user-auth.md
@@ -2022,7 +2022,7 @@ Here's the code we can add to our `view` function to make things look official:
 ```elm {3-4,18,20-30,34-115}
 module Layouts.Sidebar exposing (Settings, Model, Msg, layout)
 
-import Html.Attributes exposing (alt, class, classList, src)
+import Html.Attributes exposing (alt, class, classList, src, style)
 import Route.Path
 -- ...
 


### PR DESCRIPTION
## Problem

In the [User Authentication Guide](https://elm.land/guide/user-auth.html), when following the instructions for  [Updating View to Make Things Nice](https://elm.land/guide/user-auth.html#_3-updating-view-to-make-things-look-nice) , there seems to be a missing import for the `style` function as the compiler throws an  error about not knowing what the `style` function is.

## Solution

Add an import for the `style` function to the [Updating View to Make Things Nice](https://elm.land/guide/user-auth.html#_3-updating-view-to-make-things-look-nice) imports list.

## Notes

This fix coincides with the imports in the [05-user-auth example](https://github.com/elm-land/elm-land/blob/main/examples/05-user-auth/src/Layouts/Sidebar.elm#L6)

