### PR TITLE
Fix typos

### DIFF
--- a/docs/concepts/pages.md
+++ b/docs/concepts/pages.md
@@ -156,7 +156,7 @@ view model = ...
 
 -- AFTER
 view : Shared.Model -> Model -> View Msg
-view route model = ...
+view shared model = ...
 ```
 
 The same concept applies to `init`, `update`, and `subscriptions`. 
@@ -180,7 +180,7 @@ page shared route =
         }
 ```
 
-After we pass in the `shared` argument on line 12, we can update our `view` function to get access to `shared` in our view code:
+After we pass in the `route` argument on line 10, we can update our `init` function to get access to `route` in our view code:
 
 ```elm{6-7}
 -- BEFORE


### PR DESCRIPTION
- `route` param → `shared` param
- Fixes the 2nd example explanation (currently, it's an exact copy of the 1st example's explanation)