### PR TITLE
Wrap the record in the `Model` constructor as it's an opaque type

### DIFF
--- a/docs/concepts/components.md
+++ b/docs/concepts/components.md
@@ -695,11 +695,12 @@ update props =
                 )
 
             SelectedItem data ->
-                ( Model { model
-                    | search = ""
-                    , isMenuOpen = False
-                    , selected = Just data.item
-                  }
+                ( Model 
+                    { model
+                        | search = ""
+                        , isMenuOpen = False
+                        , selected = Just data.item
+                    }
                 , case data.onChange of
                     Just onChange ->
                         Effect.sendMsg onChange

--- a/docs/concepts/components.md
+++ b/docs/concepts/components.md
@@ -680,22 +680,22 @@ update props =
     toParentModel <|
         case props.msg of
             FocusedDropdown ->
-                ( { model | isMenuOpen = True }
+                ( Model { model | isMenuOpen = True }
                 , Effect.none
                 )
 
             BlurredDropdown ->
-                ( { model | search = "", isMenuOpen = False }
+                ( Model { model | search = "", isMenuOpen = False }
                 , Effect.none
                 )
 
             UpdatedSearchInput value ->
-                ( { model | search = value }
+                ( Model { model | search = value }
                 , Effect.none
                 )
 
             SelectedItem data ->
-                ( { model
+                ( Model { model
                     | search = ""
                     , isMenuOpen = False
                     , selected = Just data.item


### PR DESCRIPTION
Currently, `Dropdown.elm` doesn't compile. This PR fixes the issue by correctly constructing the opaque `Model` type.

P.S. It would be cool if it was possible to pull the code in the doc from the actual file. In that case, a simple `elm build` script would be enough to guarantee these kinds of issues won't be possible at all.