### PR TITLE
Fix typo

### DIFF
--- a/docs/concepts/components.md
+++ b/docs/concepts/components.md
@@ -930,10 +930,10 @@ view model =
 
 
 
-::: details Here's that example `Animals` module
+::: details Here's that example `Animal` module
 
 ```elm
-module Animals exposing (Animal, list, toName)
+module Animal exposing (Animal, list, toName)
 
 
 type Animal


### PR DESCRIPTION
`Animals` → `Animal`