### PR TITLE
Use `onMouseDown` instead of `onClick`

### DIFF
--- a/docs/concepts/components.md
+++ b/docs/concepts/components.md
@@ -821,7 +821,7 @@ view (Setting settings) =
         viewDropdownMenuItem item =
             button
                 [ class "dropdown__menu-item"
-                , onClick onMenuItemClick
+                , onMouseDown onMenuItemClick
                 ]
                 [ text (settings.toLabel item)
                 ]


### PR DESCRIPTION
Unfortunately, the code provided in `Dropdown.elm` doesn't work as expected.

If you try to select an item, you'll notice that the only thing that is being called is the `onBlur` handler. The reason behind this is that the `blur` event precedes the `click` event (which internally calls `mousedown` and `mouseup`). When the `blur` event is called, the menu along with its items gets destroyed, thus eliminating the `onClick` handler.

One solution is to replace `onClick` with `onMouseDown`. Although it gets the job done, the UX is not ideal (especially when considering a11y). Since this tutorial is just for demo purposes, I believe it's okay to make this sacrifice.