### PR TITLE
Fix typo

### DIFF
--- a/docs/concepts/shared.md
+++ b/docs/concepts/shared.md
@@ -150,7 +150,7 @@ decoder =
 -- ...
 ```
 
-The `Shared.Flags` type represents the initial data (if any) you expect to be passed in from JavaScript on startup. If you add a new `src/interop.js` file, you can define `flags` function that returns the initial data.
+The `Shared.Flags` type represents the initial data (if any) you expect to be passed in from JavaScript on startup. If you add a new `src/interop.js` file, you can define a `flags` function that returns the initial data.
 
 ### Defining flags
 


### PR DESCRIPTION
"`flags` function" → "a `flags` function"