### PR TITLE
fix: small typos

### DIFF
--- a/docs/guide/pages-and-routes.md
+++ b/docs/guide/pages-and-routes.md
@@ -277,7 +277,7 @@ page params =
 
 ```
 
-The `ALL_.elm` filename is a special filename to handle a "catch-all route". Try opening any of these URLs in your werb browser, all of them will match the new page we created!
+The `ALL_.elm` filename is a special filename to handle a "catch-all route". Try opening any of these URLs in your web browser, all of them will match the new page we created!
 
 - `http://localhost:1234/elm/compiler/tree/master/README.md`
 - `http://localhost:1234/elm-land/elm-land/tree/main/docs/README.md`

--- a/docs/guide/user-auth.md
+++ b/docs/guide/user-auth.md
@@ -526,7 +526,7 @@ If you try using the sign-in form again in your browser, you'll be able to fill 
 
 In the bottom right corner, click on the Elm debugger– you should see that the API is receiving the secret token from the backend:
 
-![The Elm debugger, showing the latest message `SignInApiReponded (Ok "ryans-secret-token")`](./user-auth/03-debugger-token.png)
+![The Elm debugger, showing the latest message `SignInApiResponded (Ok "ryans-secret-token")`](./user-auth/03-debugger-token.png)
 
 This is great, but let's have our UI correctly handle the HTTP response for both cases: when sign-in works and when it doesn't!
 


### PR DESCRIPTION
`werb` -> `web`
`SignInApiReponded` -> `SignInApiResponded`