### PR TITLE
📦 Release - v0.19.2

### DIFF
--- a/docs/.vitepress/config.js
+++ b/docs/.vitepress/config.js
@@ -1,4 +1,4 @@
-const version = '0.19.1'
+const version = '0.19.2'
 
 const sidebar = [
   {

--- a/docs/concepts/cli.md
+++ b/docs/concepts/cli.md
@@ -172,7 +172,7 @@ Here's example output of what you'd see if you ran this command in the ["Pages a
 
 ```txt
 
-  🌈  Elm Land (v0.19.1) found 5 pages in your application
+  🌈  Elm Land (v0.19.2) found 5 pages in your application
   ⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺
   src/Pages/Home_.elm ............... http://localhost:1234/
   src/Pages/SignIn.elm .............. http://localhost:1234/sign-in

--- a/docs/guide/deploying.md
+++ b/docs/guide/deploying.md
@@ -16,7 +16,7 @@ elm-land build
 
 ```txt
 
-🌈  Elm Land (v0.19.1) build was successful.
+🌈  Elm Land (v0.19.2) build was successful.
     ⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺
 ```
 

--- a/docs/guide/pages-and-routes.md
+++ b/docs/guide/pages-and-routes.md
@@ -326,7 +326,7 @@ elm-land routes
 
 ```txt
 
-  🌈  Elm Land (v0.19.1) found 6 pages in your application
+  🌈  Elm Land (v0.19.2) found 6 pages in your application
     ⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺
   src/Pages/Home_.elm ........................... /
   src/Pages/SignIn.elm .......................... /sign-in

--- a/projects/cli/README.md
+++ b/projects/cli/README.md
@@ -17,7 +17,7 @@ The `elm-land` CLI comes with everything you need to create your next web applic
 ```
 $ elm-land
 
-🌈  Welcome to Elm Land! (v0.19.1)
+🌈  Welcome to Elm Land! (v0.19.2)
     ⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺
     Here are the available commands:
 

--- a/projects/cli/package-lock.json
+++ b/projects/cli/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "elm-land",
-  "version": "0.19.1",
+  "version": "0.19.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "elm-land",
-      "version": "0.19.1",
+      "version": "0.19.2",
       "license": "ISC",
       "dependencies": {
         "@lydell/elm": "^0.19.1-12",

--- a/projects/cli/package.json
+++ b/projects/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "elm-land",
-  "version": "0.19.1",
+  "version": "0.19.2",
   "description": "Reliable web apps for everyone",
   "main": "index.js",
   "types": "./index.d.ts",

--- a/projects/cli/src/commands/_utils.js
+++ b/projects/cli/src/commands/_utils.js
@@ -96,6 +96,14 @@ let customizableFiles = {
     filepaths: ['Auth.elm'],
     description: '................... handle user authentication'
   },
+  'js': {
+    filepaths: ['interop.js'],
+    description: '......... work with JavaScript, flags, and ports'
+  },
+  'ts': {
+    filepaths: ['interop.ts'],
+    description: '......... work with TypeScript, flags, and ports'
+  },
 }
 
 module.exports = {

--- a/projects/cli/src/commands/customize.js
+++ b/projects/cli/src/commands/customize.js
@@ -32,7 +32,14 @@ let run = async ({ moduleName } = {}) => {
     return Promise.reject(Utils.notInElmLandProject)
   }
 
-  let obj = Utils.customizableFiles[moduleName]
+  let aliases = {
+    'interop': 'js',
+    'javascript': 'js',
+    'typescript': 'ts',
+    '404': 'not-found'
+  }
+
+  let obj = Utils.customizableFiles[aliases[moduleName] || moduleName]
 
 
   if (!obj) {

--- a/projects/cli/src/effects.js
+++ b/projects/cli/src/effects.js
@@ -545,7 +545,7 @@ const generateHtml = async (config) => {
     ? [toHtmlTag('title', {}, config.app.html.title)]
     : []
   let metaTags = toSelfClosingHtmlTags('meta', [
-    { name: 'elm-land', content: '0.19.1' }
+    { name: 'elm-land', content: '0.19.2' }
   ].concat(attempt(_ => config.app.html.meta)))
   let linkTags = toSelfClosingHtmlTags('link', attempt(_ => config.app.html.link))
   let scriptTags = toHtmlTags('script', attempt(_ => config.app.html.script))

--- a/projects/cli/src/effects.js
+++ b/projects/cli/src/effects.js
@@ -14,6 +14,25 @@ const { default: ElmErrorJson } = require('./vite-plugins/elm/elm-error-json.js'
 let srcPagesFolderFilepath = path.join(process.cwd(), 'src', 'Pages')
 let srcLayoutsFolderFilepath = path.join(process.cwd(), 'src', 'Layouts')
 
+process.on('uncaughtException', function (err) {
+  if (err.code === 'EPERM') {
+    console.error([
+      '',
+      Utils.intro.error('could not start the server...'),
+      `    This problem can be fixed by running the ${Terminal.pink('npm init -y')} command`,
+      `    from your terminal.`,
+      ``,
+      `    If the issue persists after running that command, please let us`,
+      `    know in the Elm Land Discord (${Terminal.dim('https://join.elm.land')})`,
+      ''
+    ].join('\n'))
+    process.exit(1)
+  } else {
+    throw err
+  }
+});
+
+
 const mode = () =>
   (process.env.NODE_ENV === 'production')
     ? 'production'
@@ -146,8 +165,6 @@ let runServer = async (options) => {
     try { debug = config.app.elm[mode()].debugger }
     catch (_) { }
 
-    const hasTsConfigJson = await Files.exists(path.join(process.cwd(), 'tsconfig.json'))
-
     // Run the vite server on options.port
     server = await Vite.createServer({
       configFile: false,
@@ -190,7 +207,6 @@ let runServer = async (options) => {
     console.log('')
     return { problem: `❗️ Had trouble starting the server...` }
   }
-
 }
 
 let lastErrorSent = undefined

--- a/projects/cli/src/templates/_elm-land/customizable/interop.js
+++ b/projects/cli/src/templates/_elm-land/customizable/interop.js
@@ -1,9 +1,9 @@
-// These are the flags passed into your Elm application
+// This returns the flags passed into your Elm application
 export const flags = async ({ env }) => {
   return {}
 }
 
 // This function is called once your Elm app is running
 export const onReady = ({ app, env }) => {
-  console.log(`Elm app is ready!`, { app, env })
+  console.log('Elm is ready', app)
 }

--- a/projects/cli/src/templates/_elm-land/customizable/interop.ts
+++ b/projects/cli/src/templates/_elm-land/customizable/interop.ts
@@ -1,0 +1,25 @@
+// This returns the flags passed into your Elm application
+export const flags = async ({ env } : ElmLand.FlagsArgs) => {
+  return {}
+}
+
+// This function is called after your Elm app starts
+export const onReady = ({ app, env } : ElmLand.OnReadyArgs) => {
+  console.log('Elm is ready', app)
+}
+
+
+// Type definitions for Elm Land
+namespace ElmLand {
+  export type FlagsArgs = {
+    env: Record<string, string>
+  }
+  export type OnReadyArgs = {
+    env: Record<string, string>
+    app: { ports?: Record<string, Port> }
+  }
+  export type Port = {
+    send?: (data: unknown) => void
+    subscribe?: (callback: (data: unknown) => unknown) => void
+  }
+}

--- a/projects/cli/src/templates/_elm-land/server/main.js
+++ b/projects/cli/src/templates/_elm-land/server/main.js
@@ -79,7 +79,7 @@ if (import.meta.hot) {
 
 }
 
-let startApp = ({ Interop }) => {
+let startApp = async ({ Interop }) => {
   // Grab environment variables, but remove the "ELM_LAND_" prefix
   let env = Object.keys(import.meta.env).reduce((env, key) => {
     if (key.startsWith('ELM_LAND_')) {
@@ -91,7 +91,7 @@ let startApp = ({ Interop }) => {
   let flags = undefined
 
   if (Interop.flags) {
-    flags = Interop.flags({ env })
+    flags = await Interop.flags({ env })
   }
 
   if (Elm && Elm.Main && Elm.Main.init) {
@@ -111,17 +111,22 @@ let startApp = ({ Interop }) => {
 
 }
 
-try {
-  // Attempt to find "interop.ts" file
-  let interopFiles = import.meta.glob('../../src/interop.ts', { eager: true })
-  startApp({ Interop: interopFiles['../../src/interop.ts'] })
-} catch (_) {
+
+const main = async () => {
   try {
-    // Attempt to find "interop.js" file
-    let interopFiles = import.meta.glob('../../src/interop.js', { eager: true })
-    startApp({ Interop: interopFiles['../../src/interop.js'] })
+    // Attempt to find "interop.ts" file
+    let interopFiles = import.meta.glob('../../src/interop.ts', { eager: true })
+    await startApp({ Interop: interopFiles['../../src/interop.ts'] })
   } catch (_) {
-    // Run application without an interop file
-    startApp({ Interop: {} })
+    try {
+      // Attempt to find "interop.js" file
+      let interopFiles = import.meta.glob('../../src/interop.js', { eager: true })
+      await startApp({ Interop: interopFiles['../../src/interop.js'] })
+    } catch (_) {
+      // Run application without an interop file
+      await startApp({ Interop: {} })
+    }
   }
 }
+
+main()

--- a/projects/cli/tests/09-elm-binary.bats
+++ b/projects/cli/tests/09-elm-binary.bats
@@ -54,7 +54,7 @@ load helpers
 
   cp -r ../../examples/01-hello-world ../../examples/01-local-hello
   cd ../../examples/01-local-hello
-  echo '{ "dependencies": { "elm-land": "file:../../projects/cli/elm-land-0.19.1.tgz" } }' > package.json
+  echo '{ "dependencies": { "elm-land": "file:../../projects/cli/elm-land-0.19.2.tgz" } }' > package.json
   npm install
 
   run npx elm-land build
@@ -72,7 +72,7 @@ load helpers
 
   cp -r ../../examples/01-hello-world ../../examples/01-local-hello
   cd ../../examples/01-local-hello
-  echo '{ "dependencies": { "elm-land": "file:../../projects/cli/elm-land-0.19.1.tgz" } }' > package.json
+  echo '{ "dependencies": { "elm-land": "file:../../projects/cli/elm-land-0.19.2.tgz" } }' > package.json
   npm install -g yarn
   yarn
 
@@ -91,7 +91,7 @@ load helpers
 
   cp -r ../../examples/01-hello-world ../../examples/01-local-hello
   cd ../../examples/01-local-hello
-  echo '{ "dependencies": { "elm-land": "file:../../projects/cli/elm-land-0.19.1.tgz" } }' > package.json
+  echo '{ "dependencies": { "elm-land": "file:../../projects/cli/elm-land-0.19.2.tgz" } }' > package.json
   npm install -g pnpm
   pnpm install
 

--- a/projects/graphql/README.md
+++ b/projects/graphql/README.md
@@ -23,7 +23,7 @@ npm install -g elm-land@latest
 ```txt
 $ elm-land graphql
 
-🌈 Elm Land (v0.19.1) wants to add a plugin!
+🌈 Elm Land (v0.19.2) wants to add a plugin!
    ⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺
    To use the `@elm-land/graphql` plugin, I'll need
    to install the NPM package and add a bit of JSON
@@ -35,14 +35,14 @@ $ elm-land graphql
 ```txt
 $ elm-land graphql build
 
-🌈  Elm Land (v0.19.1) successfully generated Elm files
+🌈  Elm Land (v0.19.2) successfully generated Elm files
     ⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺
 ```
 
 ```txt
 $ elm-land graphql watch
 
-🌈  Elm Land (v0.19.1) is watching "./graphql/*" for changes...
+🌈  Elm Land (v0.19.2) is watching "./graphql/*" for changes...
     ⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺
 ```
 
@@ -55,7 +55,7 @@ Here’s what running the CLI looks like when there’s no schema provided:
 ```
 $ elm-land graphql build
 
-🌈 Elm Land (v0.19.1) needs a GraphQL schema
+🌈 Elm Land (v0.19.2) needs a GraphQL schema
    ‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾
    You can provide one by customizing the "elm-land.json"
    file to include a "graphql.schema" field.

--- a/projects/graphql/package-lock.json
+++ b/projects/graphql/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@elm-land/graphql",
-  "version": "0.19.1",
+  "version": "0.19.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@elm-land/graphql",
-      "version": "0.19.1",
+      "version": "0.19.2",
       "license": "ISC",
       "dependencies": {
         "graphql": "16.6.0"

--- a/projects/graphql/package.json
+++ b/projects/graphql/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elm-land/graphql",
-  "version": "0.19.1",
+  "version": "0.19.2",
   "description": "Generate Elm code from GraphQL files",
   "main": "src/index.js",
   "scripts": {


### PR DESCRIPTION
## Problem

- The flags function is not async, which can be limiting for apps that need to fetch data before loading
- There's no easy way to get started with interop
- Issue #40 is still popping up for folks, and the solution isn't clear

## Solution

This is a tiny release that:
- [x] Upgrades the `flag` function to support the `async` keyword
- [x] Adds both the `elm-land customize js` and `elm-land customize ts` commands for quick interop scaffolding
- [x] Provides a friendly error message when `EPERM` errors occur for users