### PR TITLE
Fix a bug in layouts with props that use type variables

### DIFF
--- a/projects/cli/src/codegen/src/Commands/Generate.elm
+++ b/projects/cli/src/codegen/src/Commands/Generate.elm
@@ -846,7 +846,7 @@ toLayoutUrlHookCmd layouts =
         toBranch : LayoutFile -> CodeGen.Expression.Branch
         toBranch layout =
             { name =
-                "( Just (Layouts.{{name}} settings), Just (Main.Layouts.Model.{{name}} layoutModel) )"
+                "( Just (Layouts.{{name}} props), Just (Main.Layouts.Model.{{name}} layoutModel) )"
                     |> String.replace "{{name}}" (LayoutFile.toVariantName layout)
             , arguments =
                 []
@@ -1382,7 +1382,7 @@ toViewCaseExpression layouts =
                     LayoutFile.toListOfSelfAndParents layout
             in
             { name =
-                "( Just (Layouts.{{name}} settings), Just (Main.Layouts.Model.{{name}} layoutModel) )"
+                "( Just (Layouts.{{name}} props), Just (Main.Layouts.Model.{{name}} layoutModel) )"
                     |> String.replace "{{name}}" (LayoutFile.toVariantName layout)
             , arguments = []
             , expression = toViewBranchExpression True layout selfAndParentLayouts
@@ -1394,10 +1394,10 @@ toViewCaseExpression layouts =
                 toNestedLayoutExpression : LayoutFile -> List LayoutFile -> CodeGen.Expression
                 toNestedLayoutExpression current parents =
                     let
-                        settings : String
-                        settings =
+                        props : String
+                        props =
                             if original == current || isTopLevel == False then
-                                "settings"
+                                "props"
 
                             else
                                 toLayoutPropsVariableName current
@@ -1409,8 +1409,8 @@ toViewCaseExpression layouts =
                                 [ CodeGen.Expression.function
                                     { name = LayoutFile.toModuleName current ++ ".layout"
                                     , arguments =
-                                        [ "{{settings}} model.shared route"
-                                            |> String.replace "{{settings}}" settings
+                                        [ "{{props}} model.shared route"
+                                            |> String.replace "{{props}}" props
                                             |> CodeGen.Expression.value
                                         ]
                                     }
@@ -1783,7 +1783,7 @@ toUpdateLayoutCaseExpression layouts =
                         }
             in
             { name =
-                "( Just (Layouts.{{name}} settings), Just (Main.Layouts.Model.{{name}} layoutModel), Main.Layouts.Msg.{{layoutSendingMsg}} layoutMsg )"
+                "( Just (Layouts.{{name}} props), Just (Main.Layouts.Model.{{name}} layoutModel), Main.Layouts.Msg.{{layoutSendingMsg}} layoutMsg )"
                     |> String.replace "{{name}}" (LayoutFile.toVariantName layoutOptions.currentLayout)
                     |> String.replace "{{layoutSendingMsg}}" (LayoutFile.toVariantName layoutOptions.layoutSendingMsg)
             , arguments = []
@@ -1877,7 +1877,7 @@ a child layout of the layout sending a message:
         == [ { parent = Sidebar, child = Sidebar.Header }
            ]
 
-Used with `let` expressions to define the settings for a layout within an update function
+Used with `let` expressions to define the props for a layout within an update function
 
 -}
 toParentsBetween :
@@ -1907,19 +1907,19 @@ toParentsBetween options =
         )
 
 
-{-| Example: Layouts.Sidebar.layout settings model.shared route
+{-| Example: Layouts.Sidebar.layout props model.shared route
 -}
 callLayoutFunction : Maybe LayoutFile -> LayoutFile -> CodeGen.Expression
 callLayoutFunction maybeParent layout =
-    "{{moduleName}}.layout {{settings}} model.shared route"
+    "{{moduleName}}.layout {{props}} model.shared route"
         |> String.replace "{{moduleName}}" (LayoutFile.toModuleName layout)
-        |> String.replace "{{settings}}"
+        |> String.replace "{{props}}"
             (case maybeParent of
                 Just parent ->
                     toLayoutPropsVariableName parent
 
                 Nothing ->
-                    "settings"
+                    "props"
             )
         |> CodeGen.Expression.value
 
@@ -2007,7 +2007,7 @@ toSubscriptionLayoutCaseExpression layouts =
         toBranch : LayoutFile -> CodeGen.Expression.Branch
         toBranch layout =
             { name =
-                "( Just (Layouts.{{name}} settings), Just (Main.Layouts.Model.{{name}} layoutModel) )"
+                "( Just (Layouts.{{name}} props), Just (Main.Layouts.Model.{{name}} layoutModel) )"
                     |> String.replace "{{name}}" (LayoutFile.toVariantName layout)
             , arguments =
                 []
@@ -2103,11 +2103,11 @@ toParentLayoutProps { self, child, parent } =
     , annotation = Nothing
     , expression =
         CodeGen.Expression.pipeline
-            [ "{{moduleName}}.layout {{settings}} model.shared route"
+            [ "{{moduleName}}.layout {{props}} model.shared route"
                 |> String.replace "{{moduleName}}" (LayoutFile.toModuleName child)
-                |> String.replace "{{settings}}"
+                |> String.replace "{{props}}"
                     (if self == child then
-                        "settings"
+                        "props"
 
                      else
                         toLayoutPropsVariableName child

--- a/projects/cli/src/codegen/src/Commands/Generate.elm
+++ b/projects/cli/src/codegen/src/Commands/Generate.elm
@@ -1396,7 +1396,7 @@ toViewCaseExpression layouts =
                     let
                         settings : String
                         settings =
-                            if original == current then
+                            if original == current || isTopLevel == False then
                                 "settings"
 
                             else

--- a/projects/cli/src/effects.js
+++ b/projects/cli/src/effects.js
@@ -240,12 +240,19 @@ let generateElmFiles = async (config, server = undefined) => {
         server.ws.send('elm:success', { msg: 'Success!' })
       }
 
-      let layoutFilepathSegments =
-        layoutFilepaths.map(filepath => filepath.split('/'))
+      let layoutsData = layouts.map(({ filepath, contents}) => {
+        const typeVariablePattern = 'type alias Props contentMsg';
+        const isUsingTypeVariable = contents.includes(typeVariablePattern);
+
+        return {
+          segments: filepath,
+          isUsingTypeVariable
+        }
+      })
 
       let newFiles = await Codegen.generateElmLandFiles({
         pages,
-        layouts: layoutFilepathSegments,
+        layouts: layoutsData,
         router
       })
 


### PR DESCRIPTION
## Problem

If the project has a layout with props using type variables, there's an error in the generated code that throws:

```
Props type needs 1 argument, but I see 0 instead: in .elm-land/src/Layouts.elm
```

Apparently, the implementation in the code generator for layouts that use props with type variables is incomplete. This PR tries to fill the missing gaps.

## Solution

This commit updates the array of layout paths sent to the code generator, including a boolean variable indicating if the layout uses Props with type variables. In such case, the code generator creates valid code for that layout, avoiding the current error.

## Notes

Issue mentioned and discussed in [Discord](https://discord.com/channels/1026163159100313640/1026165932453793792/1128425601980702780)