### PR TITLE
Employed the 0.19.2's `elm-land customize ts` template; Added incoming data from typescript

### DIFF
--- a/examples/10-typescript-interop/src/Pages/Home_.elm
+++ b/examples/10-typescript-interop/src/Pages/Home_.elm
@@ -12,6 +12,9 @@ import View exposing (View)
 port outgoing : String -> Cmd msg
 
 
+port incoming : (String -> msg) -> Sub msg
+
+
 page : Shared.Model -> Route () -> Page Model Msg
 page shared route =
     Page.new
@@ -27,12 +30,12 @@ page shared route =
 
 
 type alias Model =
-    {}
+    String
 
 
 init : () -> ( Model, Effect Msg )
 init () =
-    ( {}
+    ( ""
     , Effect.none
     )
 
@@ -43,6 +46,7 @@ init () =
 
 type Msg
     = UserClickedAskQuestion
+    | GotData String
 
 
 update : Msg -> Model -> ( Model, Effect Msg )
@@ -53,6 +57,11 @@ update msg model =
             , Effect.sendCmd (outgoing "Ask me a question!")
             )
 
+        GotData str ->
+            ( str
+            , Effect.none
+            )
+
 
 
 -- SUBSCRIPTIONS
@@ -60,7 +69,7 @@ update msg model =
 
 subscriptions : Model -> Sub Msg
 subscriptions model =
-    Sub.none
+    incoming GotData
 
 
 
@@ -75,5 +84,7 @@ view model =
             [ Html.Events.onClick UserClickedAskQuestion
             ]
             [ Html.text "Ask me a question!" ]
+        , Html.br [] []
+        , Html.text model
         ]
     }

--- a/examples/10-typescript-interop/src/interop.ts
+++ b/examples/10-typescript-interop/src/interop.ts
@@ -1,43 +1,43 @@
 import * as String from './string'
 
-// Types for Elm Land interop functions
-namespace ElmLand {
-
-  export type FlagsFunction =
-    ({ env }: { env: Record<string, string> }) => unknown
-  
-  export type OnReadyFunction = ({ env, app }: {
-    env: Record<string, string>,
-    app : { ports?: Record<string, Port> }
-  }) => void
-  
-  export type Port = {
-    subscribe?: (callback: (data: unknown) => void) => void,
-    unsubscribe?: (callback: (data: unknown) => void) => void,
-    send?: (data: unknown) => void
-  }
+// This returns the flags passed into your Elm application
+export const flags = async ({ env }: ElmLand.FlagsArgs) => {
+  return {}
 }
 
-export const flags : ElmLand.FlagsFunction = () => {
-
-}
-
-export const onReady : ElmLand.OnReadyFunction = ({ app, env }) => {
-  app.ports?.outgoing?.subscribe?.((message : unknown) => {
+// This function is called after your Elm app starts
+export const onReady = ({ app, env }: ElmLand.OnReadyArgs) => {
+  console.log('Elm is ready', app)
+  app.ports?.outgoing?.subscribe?.((message: unknown) => {
     console.log(message)
     askTheUserAQuestion()
   })
 }
 
-
 const askTheUserAQuestion = () => {
-  let answer = window.prompt('What is your favorite animal?')
-  
+  const answer = window.prompt('What is your favorite animal?')
+
   if (answer) {
-    let length : number = String.getLengthOfString(answer)
-    let units : string = length === 1 ? 'letter' : 'letters'
-    let response : string = `Did you know that "${answer}" is ${length} ${units} long?`
-  
+    const length: number = String.getLengthOfString(answer)
+    const units: string = length === 1 ? 'letter' : 'letters'
+    const response: string =
+      `Did you know that "${answer}" is ${length} ${units} long?`
+
     window.alert(response)
+  }
+}
+
+// Type definitions for Elm Land
+namespace ElmLand {
+  export interface FlagsArgs {
+    env: Record<string, string>
+  }
+  export interface OnReadyArgs {
+    env: Record<string, string>
+    app: { ports?: Record<string, Port> }
+  }
+  export interface Port {
+    send?: (data: unknown) => void
+    subscribe?: (callback: (data: unknown) => unknown) => void
   }
 }

--- a/examples/10-typescript-interop/src/interop.ts
+++ b/examples/10-typescript-interop/src/interop.ts
@@ -12,6 +12,9 @@ export const onReady = ({ app, env }: ElmLand.OnReadyArgs) => {
     console.log(message)
     askTheUserAQuestion()
   })
+  if (ElmLand.app === null) {
+    ElmLand.app = app
+  }
 }
 
 const askTheUserAQuestion = () => {
@@ -24,6 +27,8 @@ const askTheUserAQuestion = () => {
       `Did you know that "${answer}" is ${length} ${units} long?`
 
     window.alert(response)
+
+    ElmLand.app?.ports?.incoming?.send?.(response)
   }
 }
 
@@ -40,4 +45,5 @@ namespace ElmLand {
     send?: (data: unknown) => void
     subscribe?: (callback: (data: unknown) => unknown) => void
   }
+  export let app: OnReadyArgs['app'] | null = null
 }

--- a/examples/10-typescript-interop/src/string.ts
+++ b/examples/10-typescript-interop/src/string.ts
@@ -1,9 +1,7 @@
-
-
 export const getLengthOfString = (string: string): number => {
   return string.length
 }
 
 export default {
-  getLengthOfString
+  getLengthOfString,
 }


### PR DESCRIPTION
## Problem

> What issue is this causing for Elm Land users?

See https://github.com/elm-land/elm-land/issues/130

## Solution

> How does this code change address the problem described above?

- Employed the new `elm-land customize ts` [template](https://github.com/elm-land/elm-land/blob/c7dbae6b4adc6c0f8a420a5246f3ea10d005ab22/projects/cli/src/templates/_elm-land/customizable/interop.ts)
- Added example codes dealing with incoming data from typescript

## Notes

> (Can be blank!) Are there any unrelated code changes or other notes you'd like to share regarding this PR?

`app`, by design in `elm-land`, is only available as a parameter of `onReady`. In order to call `app.ports.incoming.send`, `app` is [saved in a variable of the `ElmLand` namespace](https://github.com/kumkee/elm-land/commit/829ee83fb9edbba3cf3dcfc6098cffd7ab7cb9e0#r123675301). This solution is inspired by ~@drinkspiller~ @shnewto on Discord.