### PR TITLE
set dashCount zero when negative

### DIFF
--- a/projects/cli/src/vite-plugins/elm/elm-error-json.js
+++ b/projects/cli/src/vite-plugins/elm/elm-error-json.js
@@ -166,7 +166,7 @@ var header = function (error, problem, cwd_) {
     relativePath = absolutePath.slice(cwd.length + 1);
   }
   var dashCount = MAX_WIDTH - left.length - PREFIX.length - SPACING_COUNT - relativePath.length;
-  return "".concat(PREFIX).concat(left, " ").concat(SPACER.repeat(dashCount), " ").concat(relativePath);
+  return "".concat(PREFIX).concat(left, " ").concat(SPACER.repeat(dashCount < 0 ? 0 : dashCount), " ").concat(relativePath);
 };
 var escapeHtml = function (str) {
   return str


### PR DESCRIPTION
## Problem

https://github.com/elm-land/elm-land/blob/031733725be48432d23a5975a16a04e7517c981e/projects/cli/src/vite-plugins/elm/elm-error-json.js#L168-L169

The `dashCount` can be negative if the `relativePath` is very long, which throws an error at `String.repeat`.

## Solution

Set the `dashCount` to zero if it is negative.

## Notes

> (Can be blank!) Are there any unrelated code changes or other notes you'd like to share regarding this PR?
