### PR TITLE
Add back navigation to Effect template

### DIFF
--- a/docs/concepts/effect.md
+++ b/docs/concepts/effect.md
@@ -155,7 +155,7 @@ Go back one or more entries from the browser history. This is just like [Browser
 #### __Definition__
 
 ```elm
-Effect.popPath : Effect msg
+Effect.back : Int -> Effect msg
 ```
 
 ### `Effect.loadExternalUrl`

--- a/docs/concepts/effect.md
+++ b/docs/concepts/effect.md
@@ -128,7 +128,7 @@ Effect.replacePath :
 
 ### `Effect.popRoute`
 
-Pop the current entry from the browser history. This is just like [Browser.Navigation.back 1](https://package.elm-lang.org/packages/elm/browser/latest/Browser-Navigation#backUrl), except it doesn't require a `Key` argument.
+Pop the current entry from the browser history. This is just like [Browser.Navigation.back 1](https://package.elm-lang.org/packages/elm/browser/latest/Browser-Navigation#back), except it doesn't require a `Key` argument.
 
 #### __Definition__
 
@@ -138,7 +138,7 @@ Effect.popRoute : Effect msg
 
 ### `Effect.popPath`
 
-Pop the current entry from the browser history. This is just like [Browser.Navigation.back 1](https://package.elm-lang.org/packages/elm/browser/latest/Browser-Navigation#backUrl), except it doesn't require a `Key` argument. Same as popRoute.
+Pop the current entry from the browser history. This is just like [Browser.Navigation.back 1](https://package.elm-lang.org/packages/elm/browser/latest/Browser-Navigation#back), except it doesn't require a `Key` argument. Same as popRoute.
 
 
 #### __Definition__
@@ -149,7 +149,7 @@ Effect.popPath : Effect msg
 
 ### `Effect.back`
 
-Go back one or more entries from the browser history. This is just like [Browser.Navigation.back](https://package.elm-lang.org/packages/elm/browser/latest/Browser-Navigation#backUrl), except it doesn't require a `Key` argument.
+Go back one or more entries from the browser history. This is just like [Browser.Navigation.back](https://package.elm-lang.org/packages/elm/browser/latest/Browser-Navigation#back), except it doesn't require a `Key` argument.
 
 
 #### __Definition__

--- a/docs/concepts/effect.md
+++ b/docs/concepts/effect.md
@@ -126,6 +126,38 @@ Effect.replacePath :
     -> Effect msg
 ```
 
+### `Effect.popRoute`
+
+Pop the current entry from the browser history. This is just like [Browser.Navigation.back 1](https://package.elm-lang.org/packages/elm/browser/latest/Browser-Navigation#backUrl), except it doesn't require a `Key` argument.
+
+#### __Definition__
+
+```elm
+Effect.popRoute : Effect msg
+```
+
+### `Effect.popPath`
+
+Pop the current entry from the browser history. This is just like [Browser.Navigation.back 1](https://package.elm-lang.org/packages/elm/browser/latest/Browser-Navigation#backUrl), except it doesn't require a `Key` argument. Same as popRoute.
+
+
+#### __Definition__
+
+```elm
+Effect.popPath : Effect msg
+```
+
+### `Effect.back`
+
+Go back one or more entries from the browser history. This is just like [Browser.Navigation.back](https://package.elm-lang.org/packages/elm/browser/latest/Browser-Navigation#backUrl), except it doesn't require a `Key` argument.
+
+
+#### __Definition__
+
+```elm
+Effect.popPath : Effect msg
+```
+
 ### `Effect.loadExternalUrl`
 
 Navigate to an external URL, outside your application. This is just like [Browser.Navigation.load](https://package.elm-lang.org/packages/elm/browser/latest/Browser-Navigation#load), except it returns an `Effect` rather than a `Cmd`.

--- a/projects/cli/src/templates/_elm-land/customizable/Effect.elm
+++ b/projects/cli/src/templates/_elm-land/customizable/Effect.elm
@@ -4,6 +4,7 @@ module Effect exposing
     , sendCmd, sendMsg
     , pushRoute, replaceRoute, loadExternalUrl
     , map, toCmd
+    , popUrl
     )
 
 {-|
@@ -36,6 +37,7 @@ type Effect msg
     | PushUrl String
     | ReplaceUrl String
     | LoadExternalUrl String
+    | PopUrl
       -- SHARED
     | SendSharedMsg Shared.Msg.Msg
 
@@ -89,6 +91,7 @@ pushRoute :
 pushRoute route =
     PushUrl (Route.toString route)
 
+
 {-| Set given path as route (without any query params or hash), and make the back button go back to the current route.
 -}
 pushPath :
@@ -96,6 +99,7 @@ pushPath :
     -> Effect msg
 pushPath path =
     PushUrl (Route.toString { path = path, query = Dict.empty, hash = Nothing })
+
 
 {-| Set the new route, but replace the previous one, so clicking the back
 button **won't** go back to the previous route.
@@ -109,6 +113,7 @@ replaceRoute :
 replaceRoute route =
     ReplaceUrl (Route.toString route)
 
+
 {-| Set given path as route (without any query params or hash), but replace the previous route,
 so clicking the back button **won't** go back to the previous route
 -}
@@ -118,11 +123,17 @@ replacePath :
 replacePath path =
     ReplaceUrl (Route.toString { path = path, query = Dict.empty, hash = Nothing })
 
+
 {-| Redirect users to a new URL, somewhere external your web application.
 -}
 loadExternalUrl : String -> Effect msg
 loadExternalUrl =
     LoadExternalUrl
+
+
+popUrl : Effect msg
+popUrl =
+    PopUrl
 
 
 
@@ -149,6 +160,9 @@ map fn effect =
 
         ReplaceUrl url ->
             ReplaceUrl url
+
+        PopUrl ->
+            PopUrl
 
         LoadExternalUrl url ->
             LoadExternalUrl url
@@ -188,6 +202,9 @@ toCmd options effect =
 
         LoadExternalUrl url ->
             Browser.Navigation.load url
+
+        PopUrl ->
+            Browser.Navigation.back options.key 1
 
         SendSharedMsg sharedMsg ->
             Task.succeed sharedMsg

--- a/projects/cli/src/templates/_elm-land/customizable/Effect.elm
+++ b/projects/cli/src/templates/_elm-land/customizable/Effect.elm
@@ -4,7 +4,7 @@ module Effect exposing
     , sendCmd, sendMsg
     , pushRoute, replaceRoute, loadExternalUrl
     , map, toCmd
-    , popUrl
+    , popPath, popRoute
     )
 
 {-|
@@ -37,7 +37,7 @@ type Effect msg
     | PushUrl String
     | ReplaceUrl String
     | LoadExternalUrl String
-    | PopUrl
+    | PopRoute
       -- SHARED
     | SendSharedMsg Shared.Msg.Msg
 
@@ -131,9 +131,16 @@ loadExternalUrl =
     LoadExternalUrl
 
 
-popUrl : Effect msg
-popUrl =
-    PopUrl
+popRoute : Effect msg
+popRoute =
+    PopRoute
+
+
+{-| Convenience function to be semetric to pushUrl and pushRoute
+-}
+popPath : Effect msg
+popPath =
+    PopRoute
 
 
 
@@ -161,8 +168,8 @@ map fn effect =
         ReplaceUrl url ->
             ReplaceUrl url
 
-        PopUrl ->
-            PopUrl
+        PopRoute ->
+            PopRoute
 
         LoadExternalUrl url ->
             LoadExternalUrl url
@@ -203,7 +210,7 @@ toCmd options effect =
         LoadExternalUrl url ->
             Browser.Navigation.load url
 
-        PopUrl ->
+        PopRoute ->
             Browser.Navigation.back options.key 1
 
         SendSharedMsg sharedMsg ->

--- a/projects/cli/src/templates/_elm-land/customizable/Effect.elm
+++ b/projects/cli/src/templates/_elm-land/customizable/Effect.elm
@@ -4,7 +4,7 @@ module Effect exposing
     , sendCmd, sendMsg
     , pushRoute, replaceRoute, loadExternalUrl
     , map, toCmd
-    , popPath, popRoute
+    , back, popPath, popRoute
     )
 
 {-|
@@ -37,7 +37,7 @@ type Effect msg
     | PushUrl String
     | ReplaceUrl String
     | LoadExternalUrl String
-    | PopRoute
+    | NavigateBack Int
       -- SHARED
     | SendSharedMsg Shared.Msg.Msg
 
@@ -133,14 +133,19 @@ loadExternalUrl =
 
 popRoute : Effect msg
 popRoute =
-    PopRoute
+    NavigateBack 1
 
 
 {-| Convenience function to be semetric to pushUrl and pushRoute
 -}
 popPath : Effect msg
 popPath =
-    PopRoute
+    NavigateBack 1
+
+
+back : Int -> Effect msg
+back n =
+    NavigateBack n
 
 
 
@@ -168,8 +173,8 @@ map fn effect =
         ReplaceUrl url ->
             ReplaceUrl url
 
-        PopRoute ->
-            PopRoute
+        NavigateBack n ->
+            NavigateBack n
 
         LoadExternalUrl url ->
             LoadExternalUrl url
@@ -210,8 +215,8 @@ toCmd options effect =
         LoadExternalUrl url ->
             Browser.Navigation.load url
 
-        PopRoute ->
-            Browser.Navigation.back options.key 1
+        NavigateBack n ->
+            Browser.Navigation.back options.key n
 
         SendSharedMsg sharedMsg ->
             Task.succeed sharedMsg

--- a/projects/cli/src/templates/_elm-land/customizable/Effect.elm
+++ b/projects/cli/src/templates/_elm-land/customizable/Effect.elm
@@ -136,7 +136,7 @@ popRoute =
     NavigateBack 1
 
 
-{-| Convenience function to be semetric to pushUrl and pushRoute
+{-| Convenience function to be symmetric to pushUrl and pushRoute
 -}
 popPath : Effect msg
 popPath =


### PR DESCRIPTION
## Problem

If you want to use Browser.Navigation.back you have to customize Effect, even thou this might be used on a regular basis.

## Solution

Add a way to the Effect template to call Browser.Navigation.back, just like pushRoute.

## Notes

I have added 3 functions. As mentioned in discord: popRoute, popPath and back. This is the maximum I see useful. I am totally fine with you removing some before merging, so you can take on from here without waiting for me. But If you don't want to hurry, I can delete some lines if necessary. 

My favourite combinations are:
1. [back] - just like Browser.Navigation - no Effect namespace "pollution" with a lot of back navigation functions
2. [back, popRoute, popPath] - to have symmetry with pushX and replaceX functions and a way to go more than one page back.
3. [back, popRoute ] - so no two entries doing the exact same thing 

1 and 2 are very close, my order might change in 5 minutes again ;-) 