### PR TITLE
Fix typo

### DIFF
--- a/docs/concepts/pages.md
+++ b/docs/concepts/pages.md
@@ -361,7 +361,7 @@ route.params ==
     { repo = "elm-land"
     , user = "elm-land"
     , branch = "main"
-    , all_ = [ "README" ]
+    , all_ = [ "README.md" ]
     }
 
 -- /ryannhg/elm-spa/tree/master/README.md
@@ -369,7 +369,7 @@ route.params ==
     { repo = "ryannhg"
     , user = "elm-spa"
     , branch = "master"
-    , all_ = [ "README" ]
+    , all_ = [ "README.md" ]
     }
 
 -- /elm-land/elm-land/tree/main/projects/cli/package.json


### PR DESCRIPTION
`README` → `README.md`

The `all_` param would be equal to `[ "README.md" ]` as it does not disregard the extension.