### PR TITLE
Base tag support

### DIFF
--- a/docs/reference/elm-land-json.md
+++ b/docs/reference/elm-land-json.md
@@ -336,6 +336,51 @@ __Output__: `dist/index.html`
 ```
 :::
 
+### app.html.base
+
+::: info TYPE
+
+```elm
+String
+```
+:::
+
+The base tag in your Elm Land application can be used to specify a base URL for all the relative URLs within your application. This can be particularly useful when you have a scenario where your Elm Land application is nested within a larger site or application and you need to specify a different base URL for your Elm Land application.
+
+For example, if your Elm Land application is hosted at www.example.com/my-app, you can set the base property to "/my-app". This way, all your relative URLs will be based on this base URL.
+
+::: tip EXAMPLE
+
+__Input__: elm-land.json
+
+```jsonc {6}
+{
+  "app": {
+    // ...
+    "html": {
+      // ...
+      "base": "/my-app",
+      // ...
+    }
+  }
+}
+```
+
+__Output__: `dist/index.html`
+
+```html {4}
+<!DOCTYPE>
+<html lang="en">
+  <body>
+    <base href="/my-app">
+    <!-- ... -->
+  </body>
+    <!-- ... -->
+</html>
+```
+
+:::
+
 ### app.html.meta
 
 ::: info TYPE

--- a/docs/reference/elm-land-json.md
+++ b/docs/reference/elm-land-json.md
@@ -359,7 +359,9 @@ __Input__: elm-land.json
     // ...
     "html": {
       // ...
-      "base": "/my-app",
+      "base": {
+        "href": "/my-app/"
+      }
       // ...
     }
   }

--- a/projects/cli/src/effects.js
+++ b/projects/cli/src/effects.js
@@ -558,13 +558,16 @@ const generateHtml = async (config) => {
   let titleTags = attempt(_ => config.app.html.title)
     ? [toHtmlTag('title', {}, config.app.html.title)]
     : []
+  let baseTags = attempt(_ => config.app.html.base)
+    ? [toHtmlTag('base', {}, config.app.html.base)]
+    : []
   let metaTags = toSelfClosingHtmlTags('meta', [
     { name: 'elm-land', content: '0.19.4' }
   ].concat(attempt(_ => config.app.html.meta)))
   let linkTags = toSelfClosingHtmlTags('link', attempt(_ => config.app.html.link))
   let scriptTags = toHtmlTags('script', attempt(_ => config.app.html.script))
 
-  let combinedTags = [...titleTags, ...metaTags, ...linkTags, ...scriptTags]
+  let combinedTags = [...titleTags, ...baseTags, ...metaTags, ...linkTags, ...scriptTags]
   let headTags = combinedTags.length > 0
     ? '\n    ' + combinedTags.join('\n    ') + '\n  '
     : ''

--- a/projects/cli/src/effects.js
+++ b/projects/cli/src/effects.js
@@ -558,9 +558,7 @@ const generateHtml = async (config) => {
   let titleTags = attempt(_ => config.app.html.title)
     ? [toHtmlTag('title', {}, config.app.html.title)]
     : []
-  let baseTags = attempt(_ => config.app.html.base)
-    ? [toHtmlTag('base', {}, config.app.html.base)]
-    : []
+  let baseTags = toSelfClosingHtmlTags('base', [attempt(_ => config.app.html.base)]);
   let metaTags = toSelfClosingHtmlTags('meta', [
     { name: 'elm-land', content: '0.19.4' }
   ].concat(attempt(_ => config.app.html.meta)))


### PR DESCRIPTION
## Problem
Currently, there is no straightforward way to handle subdirectory applications in Elm Land. For instance, if you have an application living at `https://domain.com/my-app/[app-lives-here]`, you would need a custom build pipeline or some other workaround to serve the app properly.

## Solution
Adding a `base` tag can resolve this issue. This tag makes all relative paths refer to the `href` value of the tag, effectively handling the routing for subdirectory applications.

## Notes
Implementing this solution will disrupt the standard routing as it stands now but hash routing will still work. One potential way to address this issue is by configuring the router to strip the base path from the routing URL. I am still exploring the best way to implement this and would appreciate any suggestions. If you're open to this approach, I'd be happy to work on a separate PR to address it.