### PR TITLE
feat: add support for base tag

### DIFF
--- a/docs/reference/elm-land-json.md
+++ b/docs/reference/elm-land-json.md
@@ -162,6 +162,7 @@ If you ever need to audit which variables are exposed to your frontend, this one
 , meta : List (Dict String String)
 , link : List (Dict String String)
 , script : List (Dict String String)
+, base : List (Dict String String)
 }
 ```
 :::
@@ -180,6 +181,7 @@ Here is the general shape of that HTML template to give you an overview:
     {{ meta tags }}
     {{ link tags }}
     {{ script tags }}
+    {{ base tag }}
   </head>
   <body>
     <!-- Elm Land's entrypoint -->
@@ -469,6 +471,52 @@ __Output__: `dist/index.html`
   <head>
     <!-- ... -->
     <script src="https://code.jquery.com/jquery-3.6.1.min.js"></script>
+  </head>
+  <!-- ... -->
+</html>
+```
+
+:::
+
+### app.html.base
+
+::: info TYPE
+```elm
+List (Dict String String)
+```
+:::
+
+For each item in the list, an attribute will be rendered within the `<base>` tag.
+
+::: tip EXAMPLE
+
+__Input__: `elm-land.json`
+
+```jsonc {7}
+{
+  "app": {
+    // ...
+    "html": {
+      // ...
+      "base": [
+        {
+          "href": "https://href.example.elm.land" ,
+            "target": "fun"
+        }
+      ]
+    }
+  }
+}
+```
+
+__Output__: `dist/index.html`
+
+```html {5}
+<!DOCTYPE html>
+<html>
+  <head>
+    <!-- ... -->
+    <base href="https://href.example.elm.land" target="fun">
   </head>
   <!-- ... -->
 </html>

--- a/projects/cli/src/effects.js
+++ b/projects/cli/src/effects.js
@@ -564,7 +564,16 @@ const generateHtml = async (config) => {
   let linkTags = toSelfClosingHtmlTags('link', attempt(_ => config.app.html.link))
   let scriptTags = toHtmlTags('script', attempt(_ => config.app.html.script))
 
+  let baseTagsAttributes = toAttributeString(attempt(() =>  config.app.html.base ))
+  let baseTag = ''
+  if(baseTagsAttributes.length > 0){
+    baseTag = `<base${baseTagsAttributes}>`
+  }
+
   let combinedTags = [...titleTags, ...metaTags, ...linkTags, ...scriptTags]
+  if(baseTag !== ''){
+    combinedTags.push(baseTag)
+  }
   let headTags = combinedTags.length > 0
     ? '\n    ' + combinedTags.join('\n    ') + '\n  '
     : ''


### PR DESCRIPTION
## Problem

It is not possible to set the base tag in elm land.

## Solution

Read base Tag attributes from elm-land.json and add to index.html template 

## Notes

Tested manual all 4 combinations of href and target attributes. Could not get the bats test to test what I wanted (content of generated index.html should contain ...)

New attributes not used in any example project right now. I was not sure about adding an example project just for that. And use in other examples might lead to unexpected behaviour.

