### PR TITLE
fix: address flow in concepts and typo

### DIFF
--- a/docs/.vitepress/config.js
+++ b/docs/.vitepress/config.js
@@ -17,6 +17,7 @@ const sidebar = [
     text: 'Concepts',
     items: [
       { text: 'Introduction', link: '/concepts/' },
+      { text: 'CLI', link: '/concepts/cli' },
       { text: 'Pages', link: '/concepts/pages' },
       { text: 'Layouts', link: '/concepts/layouts' },
       { text: 'Components', link: '/concepts/components' },

--- a/docs/concepts/cli.md
+++ b/docs/concepts/cli.md
@@ -1,3 +1,7 @@
+---
+outline: [2,3]
+---
+
 # CLI commands
 
 ## Overview

--- a/docs/concepts/pages.md
+++ b/docs/concepts/pages.md
@@ -207,7 +207,7 @@ We recommend using `Route.href` rather than `Html.Attributes.href` when linking 
 
 ## Route naming convention 
 
-When working with pages, it's important to understand how Elm Land determines which page files to learn. If you have worked with a JavaScript application framework before, these rules should look familiar.
+When working with pages, it's important to understand how Elm Land determines which page files to load. If you have worked with a JavaScript application framework before, these rules should look familiar.
 
 Here are the categories of routes you'll find in every Elm Land project, ordered from most to least specific:
 


### PR DESCRIPTION
the pr addresses the following issues raised in Discord:

concepts/index.md (introduction) body copy refers the next section being about CLI but the next section is concepts/pages.md.
* https://discord.com/channels/1026163159100313640/1026587233630834828/1176998799466565672

small typo fix on concepts/pages: "learn" -> "load"
* https://discord.com/channels/1026163159100313640/1026587233630834828/1178156906573996134