### PR TITLE
Nested layouts with a variable in Props fail

### DIFF
--- a/examples/17-layout-props-types/src/Layouts/Sidebar.elm
+++ b/examples/17-layout-props-types/src/Layouts/Sidebar.elm
@@ -11,11 +11,12 @@ import Shared
 import View exposing (View)
 
 
-type alias Props =
-    {}
+type alias Props contentMsg =
+    { example : Html contentMsg 
+    }
 
 
-layout : Props -> Shared.Model -> Route () -> Layout () Model Msg contentMsg
+layout : Props contentMsg -> Shared.Model -> Route () -> Layout () Model Msg contentMsg
 layout props shared route =
     Layout.new
         { init = init

--- a/examples/17-layout-props-types/src/Layouts/Sidebar/Header.elm
+++ b/examples/17-layout-props-types/src/Layouts/Sidebar/Header.elm
@@ -25,7 +25,7 @@ map fn props =
     }
 
 
-layout : Props contentMsg -> Shared.Model -> Route () -> Layout Layouts.Sidebar.Props Model Msg contentMsg
+layout : Props contentMsg -> Shared.Model -> Route () -> Layout (Layouts.Sidebar.Props contentMsg) Model Msg contentMsg
 layout props shared route =
     Layout.new
         { init = init


### PR DESCRIPTION
```
🌈  Elm Land (v0.19.5) failed to build project
    ⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺
-- UNEXPECTED TYPE ANNOTATION ------------------- src/Layouts/Sidebar/Header.elm

I found an unexpected type annotation on this layout function.

  layout : Props contentMsg -> Shared.Model -> Route () -> Layout Layouts.Sidebar.Props contentMsg Model Msg contentMsg
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
I recommend one of these annotations:

  layout : Props -> Shared.Model -> Route () -> Layout Layouts.Sidebar.Props Model Msg contentMsg

  layout : Props contentMsg -> Shared.Model -> Route () -> Layout Layouts.Sidebar.Props Model Msg contentMsg

Although Elm annotations are optional, Elm Land requires an annotation for
this particular function to avoid showing errors in generated code.

Hint: Read https://elm.land/problems#unexpected-type-annotation to learn more
```