### PR TITLE
Fix error in Effect documentation

### DIFF
--- a/docs/concepts/effect.md
+++ b/docs/concepts/effect.md
@@ -370,7 +370,7 @@ map fn effect =
             SendApiRequest
                 { endpoint = data.endpoint
                 , decoder = Json.Decode.map fn data.decoder
-                , onHttpError = \err -> Json.Decode.map fn (data.onHttpError err)
+                , onHttpError = \err -> fn (data.onHttpError err)
                 }
 
 -- ...


### PR DESCRIPTION
## Problem

There is a mistake in the documentation that I ran into (and another discord user as well) while exploring `Effect` module.

## Solution

Remove the unnecessary Json.Decode.map call and makes types match.

## Notes
