### PR TITLE
Fix file watcher trying to access temporary files

### DIFF
--- a/projects/cli/src/files.js
+++ b/projects/cli/src/files.js
@@ -166,6 +166,8 @@ let listElmFilepathsInFolder = (filepath) => {
 
   if (folderExists) {
     let fullFilepaths = walk(filepath)
+      // Exclude temporary files saved by code editors, such as 'Foo.elm~'.
+      .filter(str => str.endsWith('.elm'))
     let relativeFilepaths = fullFilepaths.map(str => str.slice(filepath.length + 1, -'.elm'.length))
 
     return relativeFilepaths


### PR DESCRIPTION

## Problem

My NeoVim config saves temporary files in the same directory as the actual file, when saving a file. If I'm saving `Foo.elm`, it briefly creates a sibling file named `Foo.elm~`. Elm Land's development server notices this file appears and tries to open a file that doesn't exist, called `Foo..elm`, producing an error like this:

```
Error: ENOENT: no such file or directory, open '/home/adam/my-project/src/Pages/Language_/ALL_..elm'
    at Object.readFileSync (node:fs:453:20)
    at Object.readFromUserFolder (/home/adam/my-project/node_modules/elm-land/src/files.js:150:20)
    at /home/adam/my-project/node_modules/elm-land/src/effects.js:229:36
    at Array.map (<anonymous>)
    at generateElmFiles (/home/adam/my-project/node_modules/elm-land/src/effects.js:228:39)
    at FSWatcher.<anonymous> (/home/adam/my-project/node_modules/elm-land/src/effects.js:150:66)
    at FSWatcher.emit (node:events:514:28)
    at FSWatcher.emitWithAll (/home/adam/my-project/node_modules/chokidar/index.js:541:32)
    at FSWatcher._emit (/home/adam/my-project/node_modules/chokidar/index.js:632:8)
    at NodeFsHandler._handleFile (/home/adam/my-project/node_modules/chokidar/lib/nodefs-handler.js:400:14) {
  errno: -2,
  code: 'ENOENT',
  syscall: 'open',
  path: '/home/adam/my-project/src/Pages/Language_/ALL_..elm'
}
```

Notice the extra `.` in the filename 

## Solution

Ignore files that do not end in `.elm`.

## Notes

This fix might not be necessary with a tweaked Chokidar configuration that causes the program to only receive events for `.elm$` file changes in the first place.