### PR TITLE
fix type mismatch error and fix broken functionality

### DIFF
--- a/docs/concepts/components.md
+++ b/docs/concepts/components.md
@@ -821,10 +821,15 @@ view (Setting settings) =
         viewDropdownMenuItem item =
             button
                 [ class "dropdown__menu-item"
-                , onClick onMenuItemClick
+                , onMouseDownPreventDefaul
+                , onClick (onMenuItemClick item)
                 ]
                 [ text (settings.toLabel item)
                 ]
+
+        onMouseDownPreventDefaul : Attribute msg
+        onMouseDownPreventDefaul =
+            preventDefaultOn "mousedown" (Json.succeed ( settings.toMsg NoOp, True ))
 
         onMenuItemClick : item -> msg
         onMenuItemClick item =

--- a/docs/concepts/components.md
+++ b/docs/concepts/components.md
@@ -657,6 +657,7 @@ type Msg item msg
         { item : item
         , onChange : Maybe msg
         }
+    | NoOp
 
 
 update :


### PR DESCRIPTION
## Problem

If someone tries to use the Dropdown component described in the documentation, they will get a compilation error. And after fixing it, the component will still not work correctly: Dropdown will close before the button is pressed.

```elm
        viewDropdownMenuItem : item -> Html msg
        viewDropdownMenuItem item =
            button
                [ class "dropdown__menu-item"
                , onClick onMenuItemClick
                ]
                [ text (settings.toLabel item)
                ]

```

## Solution

The `blur` event is fired before the `click` event, so the dropdown buttons will be hidden before the `click` event is fired. To make everything work as expected, it is necessary to use `preventDefaultOn "mousedown"`.


```elm
        viewDropdownMenuItem item =
            button
                [ class "dropdown__menu-item"
                , onMouseDownPreventDefault
                , onClick (onMenuItemClick item)
                ]
                [ text (settings.toLabel item)
                ]

        onMouseDownPreventDefault : Attribute msg
        onMouseDownPreventDefault =
            preventDefaultOn "mousedown" (Json.succeed ( settings.toMsg NoOp, True ))
```

## Notes

I apologize I messed up my previous PR (#149 ). In this one I took into account the comment from @peteygao and corrected my solution. 
