### PR TITLE
Fix wrong reference in docs for loadCustomPage

### DIFF
--- a/projects/cli/src/templates/_elm-land/src/Auth/Action.elm
+++ b/projects/cli/src/templates/_elm-land/src/Auth/Action.elm
@@ -50,9 +50,9 @@ loadPageWithUser =
 
 
 {-| Rather than navigating to a different route, keep the URL, but render
-what was defined in `Auth.loadCustomPage`.
+what was defined in `Auth.viewCustomPage`.
 
-**Note:** `Auth.loadCustomPage` has access to the `Shared.Model`, so you
+**Note:** `Auth.viewCustomPage` has access to the `Shared.Model`, so you
 can render different pages in different authentication scenarios.
 
 -}


### PR DESCRIPTION
## Problem

Docs point to `Auth.loadCustomPage`, but that doesn't seem to exist, I think it was meant to point to `Auth.viewCustomPage`

## Solution

`:s/load/view`

## Notes
