### PR TITLE
Added 's' to 'Setting'

### DIFF
--- a/docs/concepts/components.md
+++ b/docs/concepts/components.md
@@ -764,7 +764,7 @@ This is an important part of making this component easier to plug in!
 
 
 view : Dropdown item msg -> Html msg
-view (Setting settings) =
+view (Settings settings) =
     let
         (Model model) =
             settings.model


### PR DESCRIPTION
I noticed an 's' missing while using the Components page explanation, so I added it.

## Problem

The explanation about Components has a typo, which confused me while reading.
Maybe it confused others, too.

## Solution

I added a single 's' to make the 'Settings' word consistent throughout.

## Notes