### PR TITLE
Fix elm-land routes command

### DIFF
--- a/projects/cli/src/commands/routes.js
+++ b/projects/cli/src/commands/routes.js
@@ -37,22 +37,22 @@ let run = async ({ url } = {}) => {
     ].join('\n'))
   }
 
-  let toKebabCase = (pascalCase) => {
-    return pascalCase.split('').map((char = '') => {
-      if (char.toUpperCase() == char) {
-        return `-${char.toLowerCase()}`
-      } else {
-        return char
-      }
-    }).join('').slice(1)
+  let toKebabCaseFromPascalCase = (str) => {
+    const re = /([A-Z][a-z0-9_]*)/g;
+    const groups = str.match(re);
+    if (groups === null) {
+      return str;
+    }
+    return groups.join("-").toLowerCase();
   }
+
   let toUrl = (segments) => {
     let isHomepage = segments.length === 1 && segments[0] === 'Home_'
     let isNotFound = segments.length === 1 && segments[0] === 'NotFound_'
     let toUrlSegment = (piece = '') => {
       if (piece === 'ALL_') return '*'
-      else if (piece.endsWith('_')) return `:${toKebabCase(piece.slice(0, -1))}`
-      else return toKebabCase(piece)
+      else if (piece.endsWith('_')) return `:${toKebabCaseFromPascalCase(piece.slice(0, -1))}`
+      else return toKebabCaseFromPascalCase(piece)
     }
 
     let urlPath =


### PR DESCRIPTION
## Problem

> What issue is this causing for Elm Land users?

The `elm-land routes` command returns an incorrect url.

Steps to repro:
- `elm-land add page /v0`
- `src/Pages/V0.elm` is created
- `elm-land routes` shows `http://localhost:1234/v-0` instead of `http://localhost:1234/v0`

The problem lies in the incorrect implementation of the [toKebabCase](https://github.com/elm-land/elm-land/blob/31beffca1e5ed3ebd93acc34d1563f566e23a617/projects/cli/src/commands/routes.js#L40) function.

See https://discord.com/channels/1026163159100313640/1026176416770953286/1181807508541669457

## Solution

> How does this code change address the problem described above?

The new implementation uses regex to fix the issue.

## Notes

> (Can be blank!) Are there any unrelated code changes or other notes you'd like to share regarding this PR?

I couldn't find any test files (besides bats) or how to run them?