### PR TITLE
Add opts arg to toBrowserDocument for elm-ui v2 animations

### DIFF
--- a/projects/cli/src/codegen/src/Commands/Generate.elm
+++ b/projects/cli/src/codegen/src/Commands/Generate.elm
@@ -153,6 +153,9 @@ mainElmModule data =
                   , CodeGen.Import.new [ "View" ]
                         |> CodeGen.Import.withExposing [ "View" ]
                   ]
+                , [ CodeGen.Import.new [ "Ui" ]
+                  , CodeGen.Import.new [ "Ui.Anim" ]
+                  ]
                 ]
         , declarations =
             [ CodeGen.Declaration.function
@@ -184,6 +187,7 @@ mainElmModule data =
                         , ( "page", CodeGen.Annotation.type_ "Main.Pages.Model.Model" )
                         , ( "layout", CodeGen.Annotation.type_ "Maybe Main.Layouts.Model.Model" )
                         , ( "shared", CodeGen.Annotation.type_ "Shared.Model" )
+                        , ( "ui", CodeGen.Annotation.type_ "Ui.State" )
                         ]
                 }
             , CodeGen.Declaration.function
@@ -249,6 +253,7 @@ mainElmModule data =
                                     , ( "page", CodeGen.Expression.value "Tuple.first page" )
                                     , ( "layout", CodeGen.Expression.value "layout |> Maybe.map Tuple.first" )
                                     , ( "shared", CodeGen.Expression.value "sharedModel" )
+                                    , ( "ui", CodeGen.Expression.value "Ui.Anim.init" )
                                     ]
                                 , CodeGen.Expression.multilineFunction
                                     { name = "Cmd.batch"
@@ -316,6 +321,7 @@ mainElmModule data =
                     , ( "Layout", [ CodeGen.Annotation.type_ "Main.Layouts.Msg.Msg" ] )
                     , ( "Shared", [ CodeGen.Annotation.type_ "Shared.Msg" ] )
                     , ( "Batch", [ CodeGen.Annotation.type_ "(List Msg)" ] )
+                    , ( "Ui", [ CodeGen.Annotation.type_ "Ui.Msg" ] )
                     ]
                 }
             , CodeGen.Declaration.function
@@ -632,7 +638,29 @@ mainElmModule data =
                                             ]
                                         ]
                               }
-                            ]
+                            , { name = "Ui"
+                              , arguments = [ CodeGen.Argument.new "uiMsg" ]
+                              , expression =
+                                    CodeGen.Expression.letIn
+                                        { let_ =
+                                            [ { argument = CodeGen.Argument.new "( newUI, uiCmd )"
+                                              , annotation = Nothing
+                                              , expression = CodeGen.Expression.value "Ui.Anim.update Ui uiMsg model.ui"
+                                              }
+                                            ]
+                                        , in_ =
+                                            CodeGen.Expression.multilineTuple
+                                                [CodeGen.Expression.recordUpdate
+                                                    { value = "model"
+                                                    , fields =
+                                                        [ ( "ui", CodeGen.Expression.value "newUI" )
+                                                        ]
+                                                    }
+                                                , CodeGen.Expression.value "uiCmd"
+                                                ]
+                                        }
+                                    }
+                                ]
                         }
                 }
             , CodeGen.Declaration.function
@@ -732,6 +760,10 @@ mainElmModule data =
                               , annotation = Just (CodeGen.Annotation.type_ "View Msg")
                               , expression = CodeGen.Expression.value "toView model"
                               }
+                            , { argument = CodeGen.Argument.new "opts_"
+                              , annotation = Nothing --Just (CodeGen.Annotation.type_ "Ui.Options msg")
+                              , expression = CodeGen.Expression.value "Ui.default |> Ui.withAnimation { toMsg = Ui, state = model.ui }"
+                              }
                             ]
                         , in_ =
                             CodeGen.Expression.multilineFunction
@@ -741,6 +773,7 @@ mainElmModule data =
                                         [ ( "shared", CodeGen.Expression.value "model.shared" )
                                         , ( "route", CodeGen.Expression.value "Route.fromUrl () model.url" )
                                         , ( "view", CodeGen.Expression.value "view_" )
+                                        , ( "opts", CodeGen.Expression.value "opts_" )
                                         ]
                                     ]
                                 }

--- a/projects/cli/src/templates/_elm-land/customizable/View.elm
+++ b/projects/cli/src/templates/_elm-land/customizable/View.elm
@@ -31,7 +31,7 @@ toBrowserDocument :
     { shared : Shared.Model.Model
     , route : Route ()
     , view : View msg
-    , opts : Ui.Options msg
+    , opts : any
     }
     -> Browser.Document msg
 toBrowserDocument { view, opts } =

--- a/projects/cli/src/templates/_elm-land/customizable/View.elm
+++ b/projects/cli/src/templates/_elm-land/customizable/View.elm
@@ -31,9 +31,10 @@ toBrowserDocument :
     { shared : Shared.Model.Model
     , route : Route ()
     , view : View msg
+    , opts : Ui.Options msg
     }
     -> Browser.Document msg
-toBrowserDocument { view } =
+toBrowserDocument { view, opts } =
     { title = view.title
     , body = view.body
     }

--- a/projects/cli/src/templates/_elm-land/customizable/ViewElmCss.elm
+++ b/projects/cli/src/templates/_elm-land/customizable/ViewElmCss.elm
@@ -31,7 +31,7 @@ toBrowserDocument :
     { shared : Shared.Model.Model
     , route : Route ()
     , view : View msg
-    , opts : Ui.Options msg
+    , opts : any
     }
     -> Browser.Document msg
 toBrowserDocument { view, opts } =

--- a/projects/cli/src/templates/_elm-land/customizable/ViewElmCss.elm
+++ b/projects/cli/src/templates/_elm-land/customizable/ViewElmCss.elm
@@ -31,9 +31,10 @@ toBrowserDocument :
     { shared : Shared.Model.Model
     , route : Route ()
     , view : View msg
+    , opts : Ui.Options msg
     }
     -> Browser.Document msg
-toBrowserDocument { view } =
+toBrowserDocument { view, opts } =
     { title = view.title
     , body = List.map Html.Styled.toUnstyled view.body
     }

--- a/projects/cli/src/templates/_elm-land/customizable/ViewElmUi.elm
+++ b/projects/cli/src/templates/_elm-land/customizable/ViewElmUi.elm
@@ -13,7 +13,7 @@ module View exposing
 -}
 
 import Browser
-import Element
+import Ui
 import Route exposing (Route)
 import Shared.Model
 
@@ -32,11 +32,12 @@ toBrowserDocument :
     { shared : Shared.Model.Model
     , route : Route ()
     , view : View msg
+    , opts : Ui.Options msg
     }
     -> Browser.Document msg
-toBrowserDocument { view } =
+toBrowserDocument { view, opts } =
     { title = view.title
-    , body = [ Element.layout view.attributes view.element ]
+    , body = [ Ui.layout opts view.attributes view.element ]
     }
 
 

--- a/projects/cli/src/templates/_elm-land/customizable/ViewElmUi.elm
+++ b/projects/cli/src/templates/_elm-land/customizable/ViewElmUi.elm
@@ -20,8 +20,8 @@ import Shared.Model
 
 type alias View msg =
     { title : String
-    , attributes : List (Element.Attribute msg)
-    , element : Element.Element msg
+    , attributes : List (Ui.Attribute msg)
+    , element : Ui.Element msg
     }
 
 
@@ -35,7 +35,7 @@ toBrowserDocument :
     , opts : Ui.Options msg
     }
     -> Browser.Document msg
-toBrowserDocument { view, opts } =
+toBrowserDocument { shared, route, view, opts } =
     { title = view.title
     , body = [ Ui.layout opts view.attributes view.element ]
     }
@@ -46,8 +46,8 @@ toBrowserDocument { view, opts } =
 map : (msg1 -> msg2) -> View msg1 -> View msg2
 map fn view =
     { title = view.title
-    , attributes = List.map (Element.mapAttribute fn) view.attributes
-    , element = Element.map fn view.element
+    , attributes = List.map (Ui.mapAttribute fn) view.attributes
+    , element = Ui.map fn view.element
     }
 
 
@@ -58,7 +58,7 @@ none : View msg
 none =
     { title = ""
     , attributes = []
-    , element = Element.none
+    , element = Ui.none
     }
 
 
@@ -73,5 +73,5 @@ fromString : String -> View msg
 fromString moduleName =
     { title = moduleName
     , attributes = []
-    , element = Element.text moduleName
+    , element = Ui.text moduleName
     }

--- a/projects/cli/src/validate/src/Worker.elm
+++ b/projects/cli/src/validate/src/Worker.elm
@@ -154,7 +154,7 @@ init flags =
                 , toCustomizableErrors customizedFiles.view
                     { types = [ "View" ]
                     , functions =
-                        [ ( "toBrowserDocument", "{ shared : Shared.Model.Model, route : Route (), view : View msg } -> Browser.Document msg" )
+                        [ ( "toBrowserDocument", "{ shared : Shared.Model.Model, route : Route (), view : View msg, opts : Ui.Options msg } -> Browser.Document msg" )
                         , ( "map", "(msg1 -> msg2) -> View msg1 -> View msg2" )
                         , ( "none", "View msg" )
                         , ( "fromString", "String -> View msg" )

--- a/projects/cli/tests/07-customize.bats
+++ b/projects/cli/tests/07-customize.bats
@@ -144,7 +144,7 @@ load helpers
 
   run elm-land customize view:elm-ui
   expectFileExists "src/View.elm"
-  expectFileContains "src/View.elm" "import Element"
+  expectFileContains "src/View.elm" "import Ui"
 
   # Clean up tmp folder
   cd ../..


### PR DESCRIPTION
## Problem

elm-ui v2 (not yet released) includes some changes, e.g. renaming to "Ui". One of the changes is the the `layout` function now takes a `Ui.Option msg` argument. Specifically for using the animations see the following:

https://github.com/mdgriffith/elm-ui/blob/fff7a755b65e6f4ecef48b3f2c886be0f2e5c97b/src/Ui.elm#L366-L377

Only updating the View.elm `toBrowserDocument` function and for example adding the Ui.msg to the shared messages causes problems.

## Solution

This is obviously just a hack and will only work when using elm-ui v2.

## Notes

Using v2 in a project can be done by cloning the 2.0 branch from https://github.com/mdgriffith/elm-ui and the v2 branch from https://github.com/mdgriffith/elm-animator and including the relevant folders in elm.json source-directories.
