### PR TITLE
Feat: add `withOnSharedMsg` helper for page/layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,25 +1,68 @@
 # Elm Land
 
+[![Npm package version](https://badgen.net/npm/v/elm-land?6)](https://npmjs.com/package/@cekrem/elm-land) [![BSD-3 Clause](https://img.shields.io/github/license/elm-land/elm-land)](https://github.com/elm-land/elm-land/blob/main/LICENSE)
 
-[![Npm package version](https://badgen.net/npm/v/elm-land?6)](https://npmjs.com/package/elm-land) [![elm-land](https://github.com/elm-land/elm-land/actions/workflows/node.js.yml/badge.svg?)](https://github.com/elm-land/elm-land/actions/workflows/node.js.yml) [![BSD-3 Clause](https://img.shields.io/github/license/elm-land/elm-land)](https://github.com/elm-land/elm-land/blob/main/LICENSE)
-
-[![Discord](https://badgen.net/discord/members/vnmYFfySbH?icon=discord&label)](https://join.elm.land) [![Twitter](https://badgen.net/badge/icon/twitter?icon=twitter&label&color=00acee)](https://twitter.com/elmland_) [![GitHub](https://badgen.net/badge/icon/github?icon=github&label&color=4078c0)](https://www.github.com/elm-land/elm-land) 
+[![Discord](https://badgen.net/discord/members/vnmYFfySbH?icon=discord&label)](https://join.elm.land) [![Twitter](https://badgen.net/badge/icon/twitter?icon=twitter&label&color=00acee)](https://twitter.com/elmland_) [![GitHub](https://badgen.net/badge/icon/github?icon=github&label&color=4078c0)](https://www.github.com/elm-land/elm-land)
 
 [![Elm Land: Reliable web apps for everyone](https://github.com/elm-land/elm-land/raw/main/docs/elm-land-banner.jpg)](https://elm.land)
 
+## 🌱 About this fork
 
-## Welcome to our repo!
+This is a friendly, thankful and respectful fork of [Elm Land](https://github.com/elm-land/elm-land), solving one specific problem: **enabling pages and layouts to react to shared messages**.
+
+### The problem
+
+Elm Land already gives pages access to the latest shared **state** (via `Shared.Model`), but there's no way for pages to react to **messages** that happen in the shared layer - like when a WebSocket message arrives, when a subscription fires, or when any event occurs that updates the shared state. Pages can respond to URL changes using `Page.withOnUrlChanged`, but not to things that _happen_ in the shared layer at a point in time.
+
+### The solution
+
+This fork adds `Page.withOnSharedMsg` and `Layout.withOnSharedMsg`, following the same pattern as existing Elm Land APIs:
+
+```elm
+page : Shared.Model -> Route () -> Page Model Msg
+page shared route =
+    Page.new
+        { init = init
+        , update = update
+        , view = view
+        , subscriptions = subscriptions
+        }
+        |> Page.withOnSharedMsg
+            (\sharedMsg ->
+                case sharedMsg of
+                    Shared.Msg.ItemsSaved ->
+                        ShowSuccessToast
+
+                    _ ->
+                        NoOp
+            )
+```
+
+### Installation
+
+```bash
+npm install --save-dev @cekrem/elm-land
+```
+
+This allows pages and layouts to "subscribe" to shared state changes, making reactive UI updates natural and eliminating the need for manual synchronization workarounds.
+
+There's a [PR](https://github.com/elm-land/elm-land/pull/205) open on this, but according to Ryan it will probably not be merged until Elm Land is out of beta (and when it is, his own solution will be more thorough).
+
+**Only use this fork if you need the functionality described above!**
+
+---
+
+## Welcome to our repo
 
 The code for this GitHub project is broken down into smaller projects:
 
-- __[elm-land](./projects/cli/)__ - The CLI tool, available at [npmjs.org/elm-land](https://npmjs.org/elm-land)
-- __[@elm-land/docs](./docs/)__ - The official website, available at [elm.land](https://elm.land)
-
+- **[elm-land](./projects/cli/)** - The CLI tool, available at [npmjs.org/elm-land](https://npmjs.org/elm-land)
+- **[@elm-land/docs](./docs/)** - The official website, available at [elm.land](https://elm.land)
 
 ### Tooling
 
 This repo also includes a few tooling projects, separated out for anyone else making tooling for Elm:
 
-- __[@elm-land/elm-error-json](./projects/tooling/elm-error-json/)__ - Render the Elm compiler's JSON error output as full-color HTML or colored ASCII terminal output
+- **[@elm-land/elm-error-json](./projects/tooling/elm-error-json/)** - Render the Elm compiler's JSON error output as full-color HTML or colored ASCII terminal output
 
-- __[@elm-land/codegen](./projects/tooling/codegen/)__ - a lightweight codegen library used internally by the Elm Land CLI
+- **[@elm-land/codegen](./projects/tooling/codegen/)** - a lightweight codegen library used internally by the Elm Land CLI

--- a/docs/reference/layout.md
+++ b/docs/reference/layout.md
@@ -139,3 +139,48 @@ update msg model =
 ```
 
 __Note:__ In [the Route section](./route), you'll learn about the `Route` type and how it stores URL information.
+
+### `Layout.withOnSharedMsg`
+
+The `Layout.withOnSharedMsg` function allows a layout to respond to events in the shared state, rather than just reading the latest shared state.
+
+This is useful when you need to react to **a point in time** (like `Browser.Events.onResize`) rather than simply displaying the current shared state in your view.
+
+#### Type definition
+
+```elm
+Layout.withOnSharedMsg :
+    (Shared.Msg -> msg)
+    -> Layout parentProps model msg contentMsg
+    -> Layout parentProps model msg contentMsg
+```
+
+#### Usage example
+
+```elm{15-20}
+module Layouts.Sidebar exposing (Props, Model, Msg, layout)
+
+import Layout exposing (Layout)
+-- ...
+
+
+layout : Props -> Shared.Model -> Route () -> Layout () Model Msg contentMsg
+layout props shared route =
+    Layout.new
+        { init = init
+        , update = update
+        , view = view
+        , subscriptions = subscriptions
+        }
+        |> Layout.withOnSharedMsg
+            (\sharedMsg ->
+                case sharedMsg of
+                    Shared.Msg.WebSocketConnected ->
+                        ShowConnectionToast
+                    
+                    _ ->
+                        NoOp
+            )
+```
+
+__Note:__ Use `Layout.withOnSharedMsg` for event-based responses. For displaying the latest shared state, simply use the `shared` argument already provided to your `layout` function.

--- a/docs/reference/page.md
+++ b/docs/reference/page.md
@@ -2,7 +2,7 @@
 
 When you see `import Page` at the top of your file, this refers to the generated Elm Land `Page` module.
 
-That module is centered around the `Page Model Msg` type, which every page creates with `Page.new`. This module also contains useful "modifier" functions that allow you to add optional features to your pages. 
+That module is centered around the `Page Model Msg` type, which every page creates with `Page.new`. This module also contains useful "modifier" functions that allow you to add optional features to your pages.
 
 Let's take a look at each function, and why you might use them in your own pages.
 
@@ -48,16 +48,15 @@ toLayout model =
         }
 ```
 
-
 ### `Page.withOnUrlChanged`
 
 The `Page.withOnUrlChanged` function allows a page to respond to any changes in the URL __that don't involve navigating to another page__.
 
-For example, going from `/dashboard` to `/settings` moves you from `Pages.Dashboard` to `Pages.Settings`. In that case, `Page.withOnUrlChanged` won't be called. 
+For example, going from `/dashboard` to `/settings` moves you from `Pages.Dashboard` to `Pages.Settings`. In that case, `Page.withOnUrlChanged` won't be called.
 
 Instead, the `Page.Settings.init` function will run to initialize the new page.
 
-Use the `Page.withOnUrlChanged` whenever you want to know if any "query parameters" or "hash" values have changed within a page. 
+Use the `Page.withOnUrlChanged` whenever you want to know if any "query parameters" or "hash" values have changed within a page.
 
 ::: tip But wait, there's more!
 
@@ -115,7 +114,7 @@ __Note:__ In [the Route section](./route), you'll learn about the `Route` type a
 
 ### `Page.withOnQueryParameterChanged`
 
-The `Page.withOnQueryParameterChanged` function allows your page to respond to changes for a certain URL query parameter. 
+The `Page.withOnQueryParameterChanged` function allows your page to respond to changes for a certain URL query parameter.
 
 This is a more specific version of `Page.onUrlChanged`, often used with filters like `?sort=name`.
 
@@ -148,7 +147,7 @@ page shared route =
         , subscriptions = subscriptions
         }
         |> Page.withOnQueryParameterChanged
-            { key = "sort" 
+            { key = "sort"
             , onChange = SortParameterChanged
             }
 
@@ -198,10 +197,9 @@ SortParameterChanged
     }
 ```
 
-
 ### `Page.withOnHashChanged`
 
-The `Page.withOnHashChanged` function allows your page to respond to changes in the hash or URL fragment. 
+The `Page.withOnHashChanged` function allows your page to respond to changes in the hash or URL fragment.
 
 This is a more specific version of `Page.onUrlChanged`, often used when jumping to certain sections on a page like `#about-us`.
 
@@ -269,3 +267,48 @@ UrlHashChanged
     , to = Just "our-mission"
     }
 ```
+
+### `Page.withOnSharedMsg`
+
+The `Page.withOnSharedMsg` function allows a page to respond to events in the shared state, rather than just reading the latest shared state.
+
+This is useful when you need to react to **a point in time** (like `Browser.Events.onResize`) rather than simply displaying the current shared state in your view.
+
+#### Type definition
+
+```elm
+Page.withOnSharedMsg :
+    (Shared.Msg -> msg)
+    -> Page model msg
+    -> Page model msg
+```
+
+#### Usage example
+
+```elm{15-20}
+module Pages.Dashboard exposing (Model, Msg, page)
+
+import Page exposing (Page)
+-- ...
+
+
+page : Shared.Model -> Route () -> Page Model Msg
+page shared route =
+    Page.new
+        { init = init
+        , update = update
+        , view = view
+        , subscriptions = subscriptions
+        }
+        |> Page.withOnSharedMsg
+            (\sharedMsg ->
+                case sharedMsg of
+                    Shared.Msg.ItemsSaved ->
+                        ShowSuccessToast
+
+                    _ ->
+                        NoOp
+            )
+```
+
+__Note:__ Use `Page.withOnSharedMsg` for event-based responses. For displaying the latest shared state, simply use the `shared` argument already provided to your `page` function.

--- a/projects/cli/package.json
+++ b/projects/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "elm-land",
-  "version": "0.21.1",
+  "version": "0.21.2",
   "description": "Reliable web apps for everyone",
   "main": "index.js",
   "type": "module",

--- a/projects/cli/package.json
+++ b/projects/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "elm-land",
-  "version": "0.20.1",
+  "version": "0.21.1",
   "description": "Reliable web apps for everyone",
   "main": "index.js",
   "type": "module",

--- a/projects/cli/src/codegen/src/Commands/Generate.elm
+++ b/projects/cli/src/codegen/src/Commands/Generate.elm
@@ -1272,17 +1272,26 @@ toLayoutSharedMsgCmd layouts =
                 , CodeGen.Expression.value "Maybe.withDefault Cmd.none"
                 ]
     in
-    CodeGen.Expression.caseExpression
-        { value = CodeGen.Argument.new "( toLayoutFromPage model, model.layout )"
-        , branches =
-            List.concat
-                [ List.map toBranch layouts
-                , [ { name = "_"
-                    , arguments = []
-                    , expression = CodeGen.Expression.value "Cmd.none"
-                    }
-                  ]
-                ]
+    CodeGen.Expression.letIn
+        { let_ =
+            [ { argument = CodeGen.Argument.new "route"
+              , annotation = Nothing
+              , expression = CodeGen.Expression.value "Route.fromUrl () model.url"
+              }
+            ]
+        , in_ =
+            CodeGen.Expression.caseExpression
+                { value = CodeGen.Argument.new "( toLayoutFromPage model, model.layout )"
+                , branches =
+                    List.concat
+                        [ List.map toBranch layouts
+                        , [ { name = "_"
+                            , arguments = []
+                            , expression = CodeGen.Expression.value "Cmd.none"
+                            }
+                          ]
+                        ]
+                }
         }
 
 

--- a/projects/cli/src/templates/_elm-land/src/Page.elm
+++ b/projects/cli/src/templates/_elm-land/src/Page.elm
@@ -3,7 +3,8 @@ module Page exposing
     , sandbox, element
     , withLayout
     , withOnUrlChanged, withOnQueryParameterChanged, withOnHashChanged
-    , init, update, view, subscriptions, layout, toUrlMessages
+    , withOnSharedMsg
+    , init, update, view, subscriptions, layout, toUrlMessages, toSharedMsg
     )
 
 {-|
@@ -12,8 +13,9 @@ module Page exposing
 @docs sandbox, element
 @docs withLayout
 @docs withOnUrlChanged, withOnQueryParameterChanged, withOnHashChanged
+@docs withOnSharedMsg
 
-@docs init, update, view, subscriptions, layout, toUrlMessages
+@docs init, update, view, subscriptions, layout, toUrlMessages, toSharedMsg
 
 -}
 
@@ -21,6 +23,7 @@ import Dict exposing (Dict)
 import Effect exposing (Effect)
 import Layouts exposing (Layout)
 import Route exposing (Route)
+import Shared
 import View exposing (View)
 
 
@@ -34,6 +37,7 @@ type Page model msg
         , onUrlChanged : Maybe ({ from : Route (), to : Route () } -> msg)
         , onHashChanged : Maybe ({ from : Maybe String, to : Maybe String } -> msg)
         , onQueryParameterChangedDict : Dict String ({ from : Maybe String, to : Maybe String } -> msg)
+        , onSharedMsg : Maybe (Shared.Msg -> msg)
         }
 
 
@@ -54,6 +58,7 @@ new options =
         , onUrlChanged = Nothing
         , onHashChanged = Nothing
         , onQueryParameterChangedDict = Dict.empty
+        , onSharedMsg = Nothing
         }
 
 
@@ -73,6 +78,7 @@ sandbox options =
         , onUrlChanged = Nothing
         , onHashChanged = Nothing
         , onQueryParameterChangedDict = Dict.empty
+        , onSharedMsg = Nothing
         }
 
 
@@ -99,6 +105,7 @@ element options =
         , onUrlChanged = Nothing
         , onHashChanged = Nothing
         , onQueryParameterChangedDict = Dict.empty
+        , onSharedMsg = Nothing
         }
 
 
@@ -151,6 +158,14 @@ withOnQueryParameterChanged :
     -> Page model msg
 withOnQueryParameterChanged { key, onChange } (Page page) =
     Page { page | onQueryParameterChangedDict = Dict.insert key onChange page.onQueryParameterChangedDict }
+
+
+withOnSharedMsg :
+    (Shared.Msg -> msg)
+    -> Page model msg
+    -> Page model msg
+withOnSharedMsg handler (Page page) =
+    Page { page | onSharedMsg = Just handler }
 
 
 
@@ -228,3 +243,8 @@ toUrlMessages routes (Page page) =
           Dict.toList page.onQueryParameterChangedDict
             |> List.filterMap toQueryParameterMessage
         ]
+
+
+toSharedMsg : Shared.Msg -> Page model msg -> Maybe msg
+toSharedMsg sharedMsg (Page page) =
+    Maybe.map (\handler -> handler sharedMsg) page.onSharedMsg


### PR DESCRIPTION
## Problem

Currently, pages and layouts can respond to URL changes within their scope using `Page.withOnUrlChanged`, `Page.withOnQueryParameterChanged`, and `Page.withOnHashChanged`. However, there's no built-in way for pages and layouts to respond to changes in the shared state that originate from other parts of the application.

This makes it difficult for pages to reactively update their UI when shared state changes (e.g., when a user logs in/out, when global settings change, or when shared data is updated by a subscription or another page). Users currently have to work around this by manually managing state synchronization or using effects to trigger page updates.

(This issue has been brought up from time to time both on the Elm Land Discord and on the Elm Community Slack, most recently the latter: https://elmlang.slack.com/archives/C0CJ3SBBM/p1755330558707299)

## Solution

This PR implements `Page.withOnSharedMsg` and `Layout.withOnSharedMsg` functions, following the same pattern as the existing `Page.withOnUrlChanged` API.

### Changes made:

1. **Page.elm & Layout.elm**: 
   - Added `onSharedMsg` field to store an optional handler function
   - Added `withOnSharedMsg` function to register a handler
   - Added `toSharedMsg` accessor function to retrieve messages for a given shared message
   - Updated module exports

2. **Code Generation (Generate.elm)**:
   - Created `toPageSharedMsgCmd` and `toLayoutSharedMsgCmd` functions that dispatch shared messages to the current page/layout
   - Integrated these functions into the main update loop's `Shared` message branch
   - Shared messages are now automatically dispatched to any pages/layouts that have registered handlers

### Usage example:

```elm
page : Shared.Model -> Route () -> Page Model Msg
page shared route =
    Page.new
        { init = init
        , update = update
        , view = view
        , subscriptions = subscriptions
        }
        |> Page.withOnSharedMsg
            (\sharedMsg ->
                case sharedMsg of
                    Shared.Msg.ItemsSaved ->
                        ShowSuccessToast
                    
                    _ ->
                        NoOp
            )

```

This allows pages and layouts to "subscribe" to shared state changes, making reactive UI updates much more natural and eliminating the need for manual synchronization workarounds.

## Notes

The implementation mirrors the `withOnUrlChanged` pattern closely for consistency with the existing Elm Land API design. The feature works for both auth-protected and non-auth-protected pages, and handles nested layouts correctly.
