### PR TITLE
Example 20: Fix function name in comment

### DIFF
--- a/examples/20-auth-error-page/src/Auth.elm
+++ b/examples/20-auth-error-page/src/Auth.elm
@@ -30,7 +30,7 @@ onPageLoad shared route =
             Auth.Action.loadCustomPage
 
 
-{-| Renders whenever `Auth.Action.showCustomView` is returned from `onPageLoad`.
+{-| Renders whenever `Auth.Action.loadCustomPage` is returned from `onPageLoad`.
 -}
 viewCustomPage : Shared.Model -> Route () -> View Never
 viewCustomPage shared route =


### PR DESCRIPTION
## Problem

Inaccurate function name in comment in example 20.

## Solution

Fix function name.
